### PR TITLE
Build time configuration for CSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ make test
 ```
 
 ## Certificate Signing Request
+
 There are two configuration options that will add a DNS name and IP address to the
-subject alternative name in the certificate signing request. 
+subject alternative name in the certificate signing request.
 By default they are not added.
-- `cmake -DCSR_DNS_NAME=charger.pionix.de ...` to include a DNS name 
-- `cmake -DCSR_IP_ADDRESS=192.168.2.1 ...` to include an IPv4 address 
+
+- `cmake -DCSR_DNS_NAME=charger.pionix.de ...` to include a DNS name
+- `cmake -DCSR_IP_ADDRESS=192.168.2.1 ...` to include an IPv4 address
 
 ## TPM
 There is a configuration option to configure OpenSSL for use with a TPM.<br>
@@ -52,6 +54,7 @@ The library will use the `UseTPM` flag and the PEM private key file to
 configure whether to use the `default` provider or the `tpm2` provider.
 
 Configuration is managed via propquery strings (see CMakeLists.txt)
+
 - `PROPQUERY_DEFAULT` is the string to use when selecting the default provider
 - `PROPQUERY_TPM2` is the string to use when selecting the tpm2 provider
 
@@ -63,6 +66,7 @@ propquery|action
 "?provider=tpm2,tpm2.digest!=yes"|prefer the tpm2 provider but not for message digests
 
 For more information see:
+
 - [Provider for integration of TPM 2.0 to OpenSSL 3.x](https://github.com/tpm2-software/tpm2-openssl)
 - [OpenSSL property](https://www.openssl.org/docs/man3.0/man7/property.html)
 - [OpenSSL provider](https://www.openssl.org/docs/man3.0/man7/provider.html)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ make -j$(nproc) install
 make test
 ```
 
+## Certificate Signing Request
+There are two configuration options that will add a DNS name and IP address to the
+subject alternative name in the certificate signing request. 
+By default they are not added.
+- `cmake -DCSR_DNS_NAME=charger.pionix.de ...` to include a DNS name 
+- `cmake -DCSR_IP_ADDRESS=192.168.2.1 ...` to include an IPv4 address 
+
 ## TPM
 There is a configuration option to configure OpenSSL for use with a TPM.<br>
 `cmake` ... `-DUSING_TPM2=ON`<br>

--- a/include/evse_security/crypto/interface/crypto_types.hpp
+++ b/include/evse_security/crypto/interface/crypto_types.hpp
@@ -5,6 +5,8 @@
 #include <chrono>
 #include <memory>
 #include <optional>
+#include <stdexcept>
+#include <string>
 
 namespace evse_security {
 
@@ -48,6 +50,11 @@ struct CertificateSigningRequestInfo {
     std::string country;
     std::string organization;
     std::string commonName;
+
+    /// @brief incude a subjectAlternativeName DNSName
+    std::optional<std::string> dns_name;
+    /// @brief incude a subjectAlternativeName IPAddress
+    std::optional<std::string> ip_address;
 
     KeyGenerationInfo key_info;
 };

--- a/lib/evse_security/CMakeLists.txt
+++ b/lib/evse_security/CMakeLists.txt
@@ -80,4 +80,16 @@ if(USING_TPM2)
     )
 endif()
 
+if(CSR_DNS_NAME)
+    target_compile_definitions(evse_security PRIVATE
+        CSR_DNS_NAME="${CSR_DNS_NAME}"
+    )
+endif()
+
+if(CSR_IP_ADDRESS)
+    target_compile_definitions(evse_security PRIVATE
+        CSR_IP_ADDRESS="${CSR_IP_ADDRESS}"
+    )
+endif()
+
 target_compile_features(evse_security PUBLIC cxx_std_17)

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <set>
 #include <stdio.h>
 
@@ -724,6 +725,16 @@ std::string EvseSecurity::generate_certificate_signing_request(LeafCertificateTy
     info.commonName = common;
     info.country = country;
     info.organization = organization;
+#ifdef CSR_DNS_NAME
+    info.dns_name = CSR_DNS_NAME;
+#else
+    info.dns_name = std::nullopt;
+#endif
+#ifdef CSR_IP_ADDRESS
+    info.ip_address = CSR_IP_ADDRESS;
+#else
+    info.ip_address = std::nullopt;
+#endif
 
     info.key_info.key_type = CryptoKeyType::EC_prime256v1;
     info.key_info.generate_on_tpm = use_tpm;

--- a/tests/openssl_supplier_test.cpp
+++ b/tests/openssl_supplier_test.cpp
@@ -1,10 +1,11 @@
 #include <cstdlib>
-#include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
-#include <iostream>
 
 #include <evse_security/crypto/openssl/openssl_supplier.hpp>
+#include <optional>
+
+// #define OUTPUT_CSR
 
 using namespace evse_security;
 
@@ -107,9 +108,81 @@ TEST_F(OpenSSLSupplierTest, x509_generate_csr) {
         "UK",
         "Pionix",
         "0123456789",
+        .dns_name = std::nullopt,
+        .ip_address = std::nullopt,
         {CryptoKeyType::EC_prime256v1, false, std::nullopt, "pki/csr_key.pem", std::nullopt}};
     auto res = OpenSSLSupplier::x509_generate_csr(csr_info, csr);
     ASSERT_TRUE(res);
+
+    std::ofstream out("csr.pem");
+    out << csr;
+    out.close();
+
+    ASSERT_GT(csr.size(), 0);
+}
+
+TEST_F(OpenSSLSupplierTest, x509_generate_csr_dns) {
+    std::string csr;
+    CertificateSigningRequestInfo csr_info = {
+        0,
+        "UK",
+        "Pionix",
+        "0123456789",
+        .dns_name = "cs.pionix.de",
+        .ip_address = std::nullopt,
+        {CryptoKeyType::EC_prime256v1, false, std::nullopt, "pki/csr_key.pem", std::nullopt}};
+    auto res = OpenSSLSupplier::x509_generate_csr(csr_info, csr);
+    ASSERT_TRUE(res);
+
+#ifdef OUTPUT_CSR
+    std::ofstream out("csr_dns.pem");
+    out << csr;
+    out.close();
+#endif
+
+    ASSERT_GT(csr.size(), 0);
+}
+
+TEST_F(OpenSSLSupplierTest, x509_generate_csr_ip) {
+    std::string csr;
+    CertificateSigningRequestInfo csr_info = {
+        0,
+        "UK",
+        "Pionix",
+        "0123456789",
+        .dns_name = std::nullopt,
+        .ip_address = "127.0.0.1",
+        {CryptoKeyType::EC_prime256v1, false, std::nullopt, "pki/csr_key.pem", std::nullopt}};
+    auto res = OpenSSLSupplier::x509_generate_csr(csr_info, csr);
+    ASSERT_TRUE(res);
+
+#ifdef OUTPUT_CSR
+    std::ofstream out("csr_ip.pem");
+    out << csr;
+    out.close();
+#endif
+
+    ASSERT_GT(csr.size(), 0);
+}
+
+TEST_F(OpenSSLSupplierTest, x509_generate_csr_dns_ip) {
+    std::string csr;
+    CertificateSigningRequestInfo csr_info = {
+        0,
+        "UK",
+        "Pionix",
+        "0123456789",
+        .dns_name = "cs.pionix.de",
+        .ip_address = "127.0.0.1",
+        {CryptoKeyType::EC_prime256v1, false, std::nullopt, "pki/csr_key.pem", std::nullopt}};
+    auto res = OpenSSLSupplier::x509_generate_csr(csr_info, csr);
+    ASSERT_TRUE(res);
+
+#ifdef OUTPUT_CSR
+    std::ofstream out("csr_dns_ip.pem");
+    out << csr;
+    out.close();
+#endif
 
     ASSERT_GT(csr.size(), 0);
 }

--- a/tests/openssl_supplier_test_tpm.cpp
+++ b/tests/openssl_supplier_test_tpm.cpp
@@ -109,6 +109,8 @@ TEST_F(OpenSSLSupplierTpmTest, x509_generate_csr) {
         "UK",
         "Pionix",
         "0123456789",
+        .dns_name = std::nullopt,
+        .ip_address = std::nullopt,
         {CryptoKeyType::EC_prime256v1, true, std::nullopt, "tpm_pki/csr_key.pem", std::nullopt}};
 
     // std::cout << "tpm2 pre: " << OSSL_PROVIDER_available(nullptr, "tpm2") << std::endl;


### PR DESCRIPTION
# Background
I'm using the client certificate as a TLS server certificate for MQTT and need to include the required subject alternative name fields in the certificate signing request (CSR).

i.e. subject alternative name can be added with DNS name and/or IPv4 address

# Implementation
By default the subject alternative name extension is not added to the CSR. When CSR_DNS_NAME or CSR_IP_ADDRESS are set using cmake then a subject alternative name extension is created and populated with the supplied values,

e.g.
```
cmake -DCSR_DNS_NAME=install.pionix.de
```

## Possible future enhancement
APIs and methods could be updated to enable run-time configuration