### PR TITLE
Fixed some potentially wrong uses of certificate hash

### DIFF
--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -129,6 +129,7 @@ namespace conversions {
 std::string encoding_format_to_string(EncodingFormat e);
 std::string ca_certificate_type_to_string(CaCertificateType e);
 std::string leaf_certificate_type_to_string(LeafCertificateType e);
+std::string leaf_certificate_type_to_filename(LeafCertificateType e);
 std::string certificate_type_to_string(CertificateType e);
 std::string hash_algorithm_to_string(HashAlgorithm e);
 std::string install_certificate_result_to_string(InstallCertificateResult e);

--- a/lib/evse_security/certificate/x509_bundle.cpp
+++ b/lib/evse_security/certificate/x509_bundle.cpp
@@ -342,6 +342,7 @@ void X509CertificateBundle::invalidate_hierarchy() {
 
 X509CertificateHierarchy& X509CertificateBundle::get_certficate_hierarchy() {
     if (hierarchy_invalidated) {
+        EVLOG_info << "Building new certificate hierarchy!";
         hierarchy_invalidated = false;
 
         auto certificates = split();

--- a/lib/evse_security/certificate/x509_wrapper.cpp
+++ b/lib/evse_security/certificate/x509_wrapper.cpp
@@ -145,6 +145,7 @@ std::string X509Wrapper::get_issuer_key_hash() const {
     if (is_selfsigned()) {
         return get_key_hash();
     } else {
+        // See 'OCPP 2.0.1 Spec: 2.6. CertificateHashDataType'
         throw std::logic_error("get_issuer_key_hash must only be used on self-signed certs");
     }
 }
@@ -170,6 +171,12 @@ CertificateHashData X509Wrapper::get_certificate_hash_data(const X509Wrapper& is
     CertificateHashData certificate_hash_data;
     certificate_hash_data.hash_algorithm = HashAlgorithm::SHA256;
     certificate_hash_data.issuer_name_hash = this->get_issuer_name_hash();
+
+    // OCPP 2.0.1 Spec: 2.6. CertificateHashDataType
+    // issuerKeyHash: The hash of the DER encoded public key: the
+    // value (excluding tag and length) of the subject public key
+    // field in the issuer’s certificate.
+
     // Issuer key hash
     certificate_hash_data.issuer_key_hash = issuer.get_key_hash();
     certificate_hash_data.serial_number = this->get_serial_number();

--- a/lib/evse_security/evse_types.cpp
+++ b/lib/evse_security/evse_types.cpp
@@ -46,6 +46,19 @@ std::string leaf_certificate_type_to_string(LeafCertificateType e) {
     }
 };
 
+std::string leaf_certificate_type_to_filename(LeafCertificateType e) {
+    switch (e) {
+    case LeafCertificateType::CSMS:
+        return "CSMS_LEAF_";
+    case LeafCertificateType::V2G:
+        return "SECC_LEAF_";
+    case LeafCertificateType::MF:
+        return "MF_LEAF_";
+    default:
+        throw std::out_of_range("Could not convert LeafCertificateType to string");
+    }
+}
+
 std::string certificate_type_to_string(CertificateType e) {
     switch (e) {
     case CertificateType::V2GRootCertificate:


### PR DESCRIPTION
## Describe your changes

A instance of using the wrong certificate hash have been fixed. The OCSP cache now builds the certificate hierarchy and retrieves the certificate hash later. A crash has been so prevented.

Naming the certificate leafs have been made clearer, from "SECC_LEAF" to "CSMS_LEAF" or "MF_LEAF" based on the LeafCertificateType.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

