### PR TITLE
Feature/get ocsp cache data

### DIFF
--- a/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/include/evse_security/certificate/x509_hierarchy.hpp
@@ -2,6 +2,7 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <algorithm>
 #include <queue>
 
 #include <evse_security/certificate/x509_wrapper.hpp>
@@ -109,6 +110,19 @@ public:
     /// @brief Builds a proper certificate hierarchy from the provided certificates. The
     /// hierarchy can be incomplete, in case orphan certificates are present in the list
     static X509CertificateHierarchy build_hierarchy(std::vector<X509Wrapper>& certificates);
+
+    template <typename... Args> static X509CertificateHierarchy build_hierarchy(Args... certificates) {
+        X509CertificateHierarchy ordered;
+
+        (std::for_each(certificates.begin(), certificates.end(),
+                       [&ordered](X509Wrapper& cert) { ordered.insert(std::move(cert)); }),
+         ...); // Fold expr
+
+        // Prune the tree
+        ordered.prune();
+
+        return ordered;
+    }
 
 private:
     /// @brief Inserts the certificate in the hierarchy. If it is not a root

--- a/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/include/evse_security/certificate/x509_hierarchy.hpp
@@ -60,6 +60,10 @@ public:
     /// @brief Searches for the provided hash, throwing a NoCertificateFound if not found
     X509Wrapper find_certificate(const CertificateHashData& hash);
 
+    /// @brief Searches for all the certificates with the provided hash, throwing a NoCertificateFound
+    // if none were found. Can be useful when we have SUB-CAs in multiple bundles
+    std::vector<X509Wrapper> find_certificates_multi(const CertificateHashData& hash);
+
 public:
     std::string to_debug_string();
 

--- a/include/evse_security/certificate/x509_wrapper.hpp
+++ b/include/evse_security/certificate/x509_wrapper.hpp
@@ -21,11 +21,6 @@ enum class X509CertificateSource {
     STRING
 };
 
-const fs::path PEM_EXTENSION = ".pem";
-const fs::path DER_EXTENSION = ".der";
-const fs::path KEY_EXTENSION = ".key";
-const fs::path TPM_KEY_EXTENSION = ".tkey";
-
 /// @brief Convenience wrapper around openssl X509 certificate
 class X509Wrapper {
 public:

--- a/include/evse_security/crypto/interface/crypto_supplier.hpp
+++ b/include/evse_security/crypto/interface/crypto_supplier.hpp
@@ -68,15 +68,20 @@ public: // X509 certificate utilities
                                                       std::optional<std::string> password);
 
     /// @brief Verifies the signature with the certificate handle public key against the data
-    static bool x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
-                                      const std::vector<std::byte>& data);
+    static bool x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
+                                      const std::vector<std::uint8_t>& data);
 
     /// @brief Generates a certificate signing request with the provided parameters
     static bool x509_generate_csr(const CertificateSigningRequestInfo& generation_info, std::string& out_csr);
 
 public: // Digesting/decoding utils
-    static bool digest_file_sha256(const fs::path& path, std::vector<std::byte>& out_digest);
-    static bool decode_base64_signature(const std::string& signature, std::vector<std::byte>& out_decoded);
+    static bool digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest);
+
+    static bool base64_decode_to_bytes(const std::string& base64_string, std::vector<std::uint8_t>& out_decoded);
+    static bool base64_decode_to_string(const std::string& base64_string, std::string& out_decoded);
+
+    static bool base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes, std::string& out_encoded);
+    static bool base64_encode_from_string(const std::string& string, std::string& out_encoded);
 };
 
 } // namespace evse_security

--- a/include/evse_security/crypto/openssl/openssl_supplier.hpp
+++ b/include/evse_security/crypto/openssl/openssl_supplier.hpp
@@ -38,14 +38,19 @@ public:
                                                                      const std::optional<fs::path> file_path);
     static KeyValidationResult x509_check_private_key(X509Handle* handle, std::string private_key,
                                                       std::optional<std::string> password);
-    static bool x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
-                                      const std::vector<std::byte>& data);
+    static bool x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
+                                      const std::vector<std::uint8_t>& data);
 
     static bool x509_generate_csr(const CertificateSigningRequestInfo& csr_info, std::string& out_csr);
 
 public:
-    static bool digest_file_sha256(const fs::path& path, std::vector<std::byte>& out_digest);
-    static bool decode_base64_signature(const std::string& signature, std::vector<std::byte>& out_decoded);
+    static bool digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest);
+
+    static bool base64_decode_to_bytes(const std::string& base64_string, std::vector<std::uint8_t>& out_decoded);
+    static bool base64_decode_to_string(const std::string& base64_string, std::string& out_decoded);
+
+    static bool base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes, std::string& out_encoded);
+    static bool base64_encode_from_string(const std::string& string, std::string& out_encoded);
 };
 
 } // namespace evse_security

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -142,6 +142,11 @@ public:
     /// @param ocsp_response the actual OCSP data
     void update_ocsp_cache(const CertificateHashData& certificate_hash_data, const std::string& ocsp_response);
 
+    /// @brief Retrieves from the OCSP cache for the given \p certificate_hash_data
+    /// @param certificate_hash_data identifies the certificate for which the \p ocsp_response is specified
+    /// @return the actual OCSP data or an exception is thrown if no data is found
+    std::optional<std::string> retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data);
+
     /// @brief Indicates if a CA certificate for the given \p certificate_type is installed on the filesystem
     /// Supports both CA certificate bundles and directories
     /// @param certificate_type

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -142,10 +142,11 @@ public:
     /// @param ocsp_response the actual OCSP data
     void update_ocsp_cache(const CertificateHashData& certificate_hash_data, const std::string& ocsp_response);
 
+    // TODO: Switch to path
     /// @brief Retrieves from the OCSP cache for the given \p certificate_hash_data
     /// @param certificate_hash_data identifies the certificate for which the \p ocsp_response is specified
     /// @return the actual OCSP data or an empty value
-    std::optional<std::string> retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data);
+    std::optional<fs::path> retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data);
 
     /// @brief Indicates if a CA certificate for the given \p certificate_type is installed on the filesystem
     /// Supports both CA certificate bundles and directories
@@ -247,7 +248,7 @@ private:
                                                             LeafCertificateType certificate_type);
     GetCertificateInfoResult get_leaf_certificate_info_internal(LeafCertificateType certificate_type,
                                                                 EncodingFormat encoding, bool include_ocsp = false);
-    std::optional<std::string> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
+    std::optional<fs::path> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
     bool is_ca_certificate_installed_internal(CaCertificateType certificate_type);
 
     /// @brief Determines if the total filesize of certificates is > than the max_filesystem_usage bytes
@@ -287,6 +288,7 @@ private:
     FRIEND_TEST(EvseSecurityTests, verify_full_filesystem_install_reject);
     FRIEND_TEST(EvseSecurityTests, verify_full_filesystem);
     FRIEND_TEST(EvseSecurityTests, verify_expired_csr_deletion);
+    FRIEND_TEST(EvseSecurityTests, verify_ocsp_garbage_collect);
     FRIEND_TEST(EvseSecurityTestsExpired, verify_expired_leaf_deletion);
 #endif
 };

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -219,6 +219,26 @@ public:
     static bool verify_file_signature(const fs::path& path, const std::string& signing_certificate,
                                       const std::string signature);
 
+    /// @brief Decodes the base64 encoded string to the raw byte representation
+    /// @param base64_string base64 encoded string
+    /// @return decoded byte vector
+    static std::vector<std::uint8_t> base64_decode_to_bytes(const std::string& base64_string);
+
+    /// @brief Decodes the base64 encoded string to string representation
+    /// @param base64_string base64 encoded string
+    /// @return decoded string array
+    static std::string base64_decode_to_string(const std::string& base64_string);
+
+    /// @brief Encodes the raw bytes to a base64 string
+    /// @param decoded_bytes raw byte array
+    /// @return encoded base64 string
+    static std::string base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes);
+
+    /// @brief Encodes the string containing raw bytes to a base64 string
+    /// @param decoded_bytes string containing raw bytes
+    /// @return encoded base64 string
+    static std::string base64_encode_from_string(const std::string& string);
+
 private:
     // Internal versions of the functions do not lock the mutex
     CertificateValidationResult verify_certificate_internal(const std::string& certificate_chain,

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -186,8 +186,10 @@ public:
     /// the leaf including any possible SUBCAs
     /// @param certificate_type type of the leaf certificate
     /// @param encoding specifies PEM or DER format
+    /// @param include_ocsp if OCSP data should be included
     /// @return contains response result
-    GetKeyPairResult get_key_pair(LeafCertificateType certificate_type, EncodingFormat encoding);
+    GetCertificateInfoResult get_leaf_certificate_info(LeafCertificateType certificate_type, EncodingFormat encoding,
+                                                       bool include_ocsp = false);
 
     /// @brief Checks and updates the symlinks for the V2G leaf certificates and keys to the most recent valid one
     /// @return true if one of the links was updated
@@ -243,7 +245,9 @@ private:
     // Internal versions of the functions do not lock the mutex
     CertificateValidationResult verify_certificate_internal(const std::string& certificate_chain,
                                                             LeafCertificateType certificate_type);
-    GetKeyPairResult get_key_pair_internal(LeafCertificateType certificate_type, EncodingFormat encoding);
+    GetCertificateInfoResult get_leaf_certificate_info_internal(LeafCertificateType certificate_type,
+                                                                EncodingFormat encoding, bool include_ocsp = false);
+    std::optional<std::string> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
     bool is_ca_certificate_installed_internal(CaCertificateType certificate_type);
 
     /// @brief Determines if the total filesize of certificates is > than the max_filesystem_usage bytes

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -144,7 +144,7 @@ public:
 
     /// @brief Retrieves from the OCSP cache for the given \p certificate_hash_data
     /// @param certificate_hash_data identifies the certificate for which the \p ocsp_response is specified
-    /// @return the actual OCSP data or an exception is thrown if no data is found
+    /// @return the actual OCSP data or an empty value
     std::optional<std::string> retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data);
 
     /// @brief Indicates if a CA certificate for the given \p certificate_type is installed on the filesystem

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -76,7 +76,7 @@ enum class GetInstalledCertificatesStatus {
     NotFound,
 };
 
-enum class GetKeyPairStatus {
+enum class GetCertificateInfoStatus {
     Accepted,
     Rejected,
     NotFound,
@@ -123,15 +123,25 @@ struct OCSPRequestData {
 struct OCSPRequestDataList {
     std::vector<OCSPRequestData> ocsp_request_data_list; ///< A list of OCSP request data
 };
-struct KeyPair {
-    fs::path key;                        ///< The path of the PEM or DER encoded private key
-    fs::path certificate;                ///< The path of the PEM or DER encoded certificate chain
-    fs::path certificate_single;         ///< The path of the PEM or DER encoded certificate
-    std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
+
+struct CertificateOCSP {
+    CertificateHashData hash;
+    std::optional<fs::path> oscsp_data;
 };
-struct GetKeyPairResult {
-    GetKeyPairStatus status;
-    std::optional<KeyPair> pair;
+
+struct CertificateInfo {
+    fs::path key;                               ///< The path of the PEM or DER encoded private key
+    std::optional<fs::path> certificate;        ///< The path of the PEM or DER encoded certificate chain if found
+    std::optional<fs::path> certificate_single; ///< The path of the PEM or DER encoded certificate if found
+    int certificate_count; ///< The count of certificates in the chain, if the chain is available, or if single 1
+    std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
+    std::vector<CertificateOCSP>
+        oscsp; ///< Contains the ordered list of OCSP certificate data based on the chain file order
+};
+
+struct GetCertificateInfoResult {
+    GetCertificateInfoStatus status;
+    std::optional<CertificateInfo> info;
 };
 
 namespace conversions {
@@ -144,7 +154,7 @@ std::string hash_algorithm_to_string(HashAlgorithm e);
 std::string install_certificate_result_to_string(InstallCertificateResult e);
 std::string delete_certificate_result_to_string(DeleteCertificateResult e);
 std::string get_installed_certificates_status_to_string(GetInstalledCertificatesStatus e);
-std::string get_key_pair_status_to_string(GetKeyPairStatus e);
+std::string get_certificate_info_status_to_string(GetCertificateInfoStatus e);
 } // namespace conversions
 
 } // namespace evse_security

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -10,6 +10,12 @@
 
 namespace evse_security {
 
+const fs::path PEM_EXTENSION = ".pem";
+const fs::path DER_EXTENSION = ".der";
+const fs::path KEY_EXTENSION = ".key";
+const fs::path TPM_KEY_EXTENSION = ".tkey";
+const fs::path CERT_HASH_EXTENSION = ".hash";
+
 enum class EncodingFormat {
     DER,
     PEM,
@@ -125,8 +131,8 @@ struct OCSPRequestDataList {
 };
 
 struct CertificateOCSP {
-    CertificateHashData hash;
-    std::optional<std::string> oscsp_data;
+    CertificateHashData hash;          ///< Hash of the certificate for which the OCSP data is held
+    std::optional<fs::path> ocsp_path; ///< Path to the file in which the certificate OCSP data is held
 };
 
 struct CertificateInfo {
@@ -142,13 +148,6 @@ struct GetCertificateInfoResult {
     GetCertificateInfoStatus status;
     std::optional<CertificateInfo> info;
 };
-
-const fs::path PEM_EXTENSION = ".pem";
-const fs::path DER_EXTENSION = ".der";
-const fs::path KEY_EXTENSION = ".key";
-const fs::path TPM_KEY_EXTENSION = ".tkey";
-const fs::path CERT_HASH_EXTENSION = ".hash";
-
 namespace conversions {
 std::string encoding_format_to_string(EncodingFormat e);
 std::string ca_certificate_type_to_string(CaCertificateType e);
@@ -156,7 +155,7 @@ std::string leaf_certificate_type_to_string(LeafCertificateType e);
 std::string leaf_certificate_type_to_filename(LeafCertificateType e);
 std::string certificate_type_to_string(CertificateType e);
 std::string hash_algorithm_to_string(HashAlgorithm e);
-HashAlgorithm string_to_hash_algorithm(std::string s);
+HashAlgorithm string_to_hash_algorithm(const std::string& s);
 std::string install_certificate_result_to_string(InstallCertificateResult e);
 std::string delete_certificate_result_to_string(DeleteCertificateResult e);
 std::string get_installed_certificates_status_to_string(GetInstalledCertificatesStatus e);

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -144,6 +144,12 @@ struct GetCertificateInfoResult {
     std::optional<CertificateInfo> info;
 };
 
+const fs::path PEM_EXTENSION = ".pem";
+const fs::path DER_EXTENSION = ".der";
+const fs::path KEY_EXTENSION = ".key";
+const fs::path TPM_KEY_EXTENSION = ".tkey";
+const fs::path CERT_HASH_EXTENSION = ".hash";
+
 namespace conversions {
 std::string encoding_format_to_string(EncodingFormat e);
 std::string ca_certificate_type_to_string(CaCertificateType e);

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -126,7 +126,7 @@ struct OCSPRequestDataList {
 
 struct CertificateOCSP {
     CertificateHashData hash;
-    std::optional<fs::path> oscsp_data;
+    std::optional<std::string> oscsp_data;
 };
 
 struct CertificateInfo {
@@ -135,7 +135,7 @@ struct CertificateInfo {
     std::optional<fs::path> certificate_single; ///< The path of the PEM or DER encoded certificate if found
     int certificate_count;               ///< The count of certificates, if the chain is available, or 1 if single
     std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
-    std::vector<CertificateOCSP> oscsp;  ///< The ordered list of OCSP certificate data based on the chain file order
+    std::vector<CertificateOCSP> ocsp;   ///< The ordered list of OCSP certificate data based on the chain file order
 };
 
 struct GetCertificateInfoResult {
@@ -156,6 +156,7 @@ std::string leaf_certificate_type_to_string(LeafCertificateType e);
 std::string leaf_certificate_type_to_filename(LeafCertificateType e);
 std::string certificate_type_to_string(CertificateType e);
 std::string hash_algorithm_to_string(HashAlgorithm e);
+HashAlgorithm string_to_hash_algorithm(std::string s);
 std::string install_certificate_result_to_string(InstallCertificateResult e);
 std::string delete_certificate_result_to_string(DeleteCertificateResult e);
 std::string get_installed_certificates_status_to_string(GetInstalledCertificatesStatus e);

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -133,10 +133,9 @@ struct CertificateInfo {
     fs::path key;                               ///< The path of the PEM or DER encoded private key
     std::optional<fs::path> certificate;        ///< The path of the PEM or DER encoded certificate chain if found
     std::optional<fs::path> certificate_single; ///< The path of the PEM or DER encoded certificate if found
-    int certificate_count; ///< The count of certificates in the chain, if the chain is available, or if single 1
+    int certificate_count;               ///< The count of certificates, if the chain is available, or 1 if single
     std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
-    std::vector<CertificateOCSP>
-        oscsp; ///< Contains the ordered list of OCSP certificate data based on the chain file order
+    std::vector<CertificateOCSP> oscsp;  ///< The ordered list of OCSP certificate data based on the chain file order
 };
 
 struct GetCertificateInfoResult {

--- a/include/evse_security/utils/evse_filesystem.hpp
+++ b/include/evse_security/utils/evse_filesystem.hpp
@@ -6,6 +6,8 @@
 
 #include <evse_security/utils/evse_filesystem_types.hpp>
 
+struct CertificateHashData;
+
 namespace evse_security::filesystem_utils {
 
 bool is_subdirectory(const fs::path& base, const fs::path& subdir);
@@ -24,5 +26,9 @@ bool process_file(const fs::path& file_path, size_t buffer_size,
                   std::function<bool(const std::uint8_t*, std::size_t, bool last_chunk)>&& func);
 
 std::string get_random_file_name(const std::string& extension);
+
+/// @brief Attempts to read a certificate hash from a file. The extension is taken into account
+/// @return True if we could read, false otherwise
+bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_hash);
 
 } // namespace evse_security::filesystem_utils

--- a/include/evse_security/utils/evse_filesystem.hpp
+++ b/include/evse_security/utils/evse_filesystem.hpp
@@ -31,4 +31,8 @@ std::string get_random_file_name(const std::string& extension);
 /// @return True if we could read, false otherwise
 bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_hash);
 
+/// @brief Attempts to write a certificate hash to a file
+/// @return True if we could write, false otherwise
+bool write_hash_to_file(const fs::path& file_path, const CertificateHashData& hash);
+
 } // namespace evse_security::filesystem_utils

--- a/include/evse_security/utils/evse_filesystem.hpp
+++ b/include/evse_security/utils/evse_filesystem.hpp
@@ -21,7 +21,7 @@ bool write_to_file(const fs::path& file_path, const std::string& data, std::ios:
 /// returns false, this function will also immediately  return
 /// @return True if the file was properly opened false otherwise
 bool process_file(const fs::path& file_path, size_t buffer_size,
-                  std::function<bool(const std::byte*, std::size_t, bool last_chunk)>&& func);
+                  std::function<bool(const std::uint8_t*, std::size_t, bool last_chunk)>&& func);
 
 std::string get_random_file_name(const std::string& extension);
 

--- a/lib/evse_security/certificate/x509_bundle.cpp
+++ b/lib/evse_security/certificate/x509_bundle.cpp
@@ -3,6 +3,7 @@
 #include <evse_security/certificate/x509_bundle.hpp>
 
 #include <algorithm>
+#include <fstream>
 
 #include <everest/logging.hpp>
 #include <evse_security/crypto/evse_crypto.hpp>
@@ -43,6 +44,20 @@ X509CertificateBundle::X509CertificateBundle(const std::string& certificate, con
 X509CertificateBundle::X509CertificateBundle(const fs::path& path, const EncodingFormat encoding) :
     hierarchy_invalidated(true) {
     this->path = path;
+
+    // In case the path is missing, create it
+    if (fs::exists(path) == false) {
+        if (path.has_extension()) {
+            if (path.extension() == PEM_EXTENSION) {
+                // Create file if we have an PEM extension
+                std::ofstream new_file(path.c_str());
+                new_file.close();
+            }
+        } else {
+            // Else create a directory
+            fs::create_directories(path);
+        }
+    }
 
     if (fs::is_directory(path)) {
         source = X509CertificateSource::DIRECTORY;

--- a/lib/evse_security/certificate/x509_hierarchy.cpp
+++ b/lib/evse_security/certificate/x509_hierarchy.cpp
@@ -97,6 +97,20 @@ X509Wrapper X509CertificateHierarchy::find_certificate(const CertificateHashData
     throw NoCertificateFound("Could not find a certificate for hash: " + hash.issuer_name_hash);
 }
 
+std::vector<X509Wrapper> X509CertificateHierarchy::find_certificates_multi(const CertificateHashData& hash) {
+    std::vector<X509Wrapper> certificates;
+
+    for_each([&](X509Node& node) {
+        if (node.hash == hash) {
+            certificates.push_back(node.certificate);
+        }
+
+        return true;
+    });
+
+    return certificates;
+}
+
 std::string X509CertificateHierarchy::to_debug_string() {
     std::stringstream str;
 

--- a/lib/evse_security/crypto/interface/crypto_supplier.cpp
+++ b/lib/evse_security/crypto/interface/crypto_supplier.cpp
@@ -86,8 +86,8 @@ KeyValidationResult AbstractCryptoSupplier::x509_check_private_key(X509Handle* h
     default_crypto_supplier_usage_error() return KeyValidationResult::Unknown;
 }
 
-bool AbstractCryptoSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
-                                                   const std::vector<std::byte>& data) {
+bool AbstractCryptoSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
+                                                   const std::vector<std::uint8_t>& data) {
     default_crypto_supplier_usage_error() return false;
 }
 
@@ -95,12 +95,25 @@ bool AbstractCryptoSupplier::x509_generate_csr(const CertificateSigningRequestIn
     default_crypto_supplier_usage_error() return false;
 }
 
-bool AbstractCryptoSupplier::digest_file_sha256(const fs::path& path, std::vector<std::byte>& out_digest) {
+bool AbstractCryptoSupplier::digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest) {
     default_crypto_supplier_usage_error() return false;
 }
 
-bool AbstractCryptoSupplier::decode_base64_signature(const std::string& signature,
-                                                     std::vector<std::byte>& out_decoded) {
+bool AbstractCryptoSupplier::base64_decode_to_bytes(const std::string& base64_string,
+                                                    std::vector<std::uint8_t>& out_decoded) {
+    default_crypto_supplier_usage_error() return false;
+}
+
+bool AbstractCryptoSupplier::base64_decode_to_string(const std::string& base64_string, std::string& out_decoded) {
+    default_crypto_supplier_usage_error() return false;
+}
+
+bool AbstractCryptoSupplier::base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes,
+                                                      std::string& out_encoded) {
+    default_crypto_supplier_usage_error() return false;
+}
+
+bool AbstractCryptoSupplier::base64_encode_from_string(const std::string& string, std::string& out_encoded) {
     default_crypto_supplier_usage_error() return false;
 }
 

--- a/lib/evse_security/crypto/openssl/openssl_supplier.cpp
+++ b/lib/evse_security/crypto/openssl/openssl_supplier.cpp
@@ -900,26 +900,32 @@ static bool base64_encode(const unsigned char* bytes_str, int bytes_size, std::s
     }
 
     EVP_EncodeInit(base64_encode_context_ptr.get());
+    // evp_encode_ctx_set_flags(base64_encode_context_ptr.get(), EVP_ENCODE_CTX_NO_NEWLINES); // Of course it's not
+    // public
+
     if (!base64_encode_context_ptr.get()) {
         EVLOG_error << "Error during EVP_EncodeInit";
         return false;
     }
 
-    int base64_length = ((bytes_size * 4) / 3) + 1;
-    char base64_out[base64_length]; // If it causes issues, replace with 'alloca' on different platform
+    int base64_length = ((bytes_size / 3) * 4) + 2;
+    // If it causes issues, replace with 'alloca' on different platform
+    char base64_out[base64_length + 66]; // + 66 bytes for final block
+    int full_len = 0;
 
     int base64_out_length;
     if (EVP_EncodeUpdate(base64_encode_context_ptr.get(), reinterpret_cast<unsigned char*>(base64_out),
-                         &base64_out_length, bytes_str, base64_length) < 0) {
+                         &base64_out_length, bytes_str, bytes_size) < 0) {
         EVLOG_error << "Error during EVP_EncodeUpdate";
         return false;
     }
+    full_len += base64_out_length;
 
-    int encode_final_out;
-    EVP_EncodeFinal(base64_encode_context_ptr.get(), reinterpret_cast<unsigned char*>(base64_out), &encode_final_out);
+    EVP_EncodeFinal(base64_encode_context_ptr.get(), reinterpret_cast<unsigned char*>(base64_out) + base64_out_length,
+                    &base64_out_length);
+    full_len += base64_out_length;
 
-    out_encoded.clear();
-    out_encoded.insert(std::end(out_encoded), base64_out, base64_out + base64_out_length);
+    out_encoded.assign(base64_out, full_len);
 
     return true;
 }

--- a/lib/evse_security/crypto/openssl/openssl_supplier.cpp
+++ b/lib/evse_security/crypto/openssl/openssl_supplier.cpp
@@ -653,8 +653,8 @@ KeyValidationResult OpenSSLSupplier::x509_check_private_key(X509Handle* handle, 
     }
 }
 
-bool OpenSSLSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
-                                            const std::vector<std::byte>& data) {
+bool OpenSSLSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
+                                            const std::vector<std::uint8_t>& data) {
     OpenSSLProvider provider;
     provider.set_global_mode(OpenSSLProvider::mode_t::default_provider);
     // extract public key
@@ -802,7 +802,7 @@ bool OpenSSLSupplier::x509_generate_csr(const CertificateSigningRequestInfo& csr
     return true;
 }
 
-bool OpenSSLSupplier::digest_file_sha256(const fs::path& path, std::vector<std::byte>& out_digest) {
+bool OpenSSLSupplier::digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest) {
     EVP_MD_CTX_ptr md_context_ptr(EVP_MD_CTX_create());
     if (!md_context_ptr.get()) {
         EVLOG_error << "Could not create EVP_MD_CTX";
@@ -818,11 +818,11 @@ bool OpenSSLSupplier::digest_file_sha256(const fs::path& path, std::vector<std::
     bool digest_error = false;
 
     unsigned int sha256_out_length = 0;
-    std::byte sha256_out[EVP_MAX_MD_SIZE];
+    std::uint8_t sha256_out[EVP_MAX_MD_SIZE];
 
     // calculate sha256 of file
     bool processed_file = filesystem_utils::process_file(
-        path, BUFSIZ, [&](const std::byte* bytes, std::size_t read, bool last_chunk) -> bool {
+        path, BUFSIZ, [&](const std::uint8_t* bytes, std::size_t read, bool last_chunk) -> bool {
             if (read > 0) {
                 if (EVP_DigestUpdate(md_context_ptr.get(), bytes, read) == 0) {
                     EVLOG_error << "Error during EVP_DigestUpdate";
@@ -854,8 +854,7 @@ bool OpenSSLSupplier::digest_file_sha256(const fs::path& path, std::vector<std::
     return true;
 }
 
-bool OpenSSLSupplier::decode_base64_signature(const std::string& signature, std::vector<std::byte>& out_decoded) {
-    // decode base64 encoded signature
+template <typename T> static bool base64_decode(const std::string& base64_string, T& out_decoded) {
     EVP_ENCODE_CTX_ptr base64_decode_context_ptr(EVP_ENCODE_CTX_new());
     if (!base64_decode_context_ptr.get()) {
         EVLOG_error << "Error during EVP_ENCODE_CTX_new";
@@ -868,28 +867,77 @@ bool OpenSSLSupplier::decode_base64_signature(const std::string& signature, std:
         return false;
     }
 
-    const unsigned char* signature_str = reinterpret_cast<const unsigned char*>(signature.data());
-    int base64_length = signature.size();
-    std::byte signature_out[base64_length];
+    const unsigned char* encoded_str = reinterpret_cast<const unsigned char*>(base64_string.data());
+    int base64_length = base64_string.size();
 
-    int signature_out_length;
-    if (EVP_DecodeUpdate(base64_decode_context_ptr.get(), reinterpret_cast<unsigned char*>(signature_out),
-                         &signature_out_length, signature_str, base64_length) < 0) {
+    std::uint8_t decoded_out[base64_length];
+
+    int decoded_out_length;
+    if (EVP_DecodeUpdate(base64_decode_context_ptr.get(), reinterpret_cast<unsigned char*>(decoded_out),
+                         &decoded_out_length, encoded_str, base64_length) < 0) {
         EVLOG_error << "Error during DecodeUpdate";
         return false;
     }
 
     int decode_final_out;
-    if (EVP_DecodeFinal(base64_decode_context_ptr.get(), reinterpret_cast<unsigned char*>(signature_out),
+    if (EVP_DecodeFinal(base64_decode_context_ptr.get(), reinterpret_cast<unsigned char*>(decoded_out),
                         &decode_final_out) < 0) {
         EVLOG_error << "Error during EVP_DecodeFinal";
         return false;
     }
 
     out_decoded.clear();
-    out_decoded.insert(std::end(out_decoded), signature_out, signature_out + signature_out_length);
+    out_decoded.insert(std::end(out_decoded), decoded_out, decoded_out + decoded_out_length);
 
     return true;
+}
+
+static bool base64_encode(const unsigned char* bytes_str, int bytes_size, std::string& out_encoded) {
+    EVP_ENCODE_CTX_ptr base64_encode_context_ptr(EVP_ENCODE_CTX_new());
+    if (!base64_encode_context_ptr.get()) {
+        EVLOG_error << "Error during EVP_ENCODE_CTX_new";
+        return false;
+    }
+
+    EVP_EncodeInit(base64_encode_context_ptr.get());
+    if (!base64_encode_context_ptr.get()) {
+        EVLOG_error << "Error during EVP_EncodeInit";
+        return false;
+    }
+
+    int base64_length = ((bytes_size * 4) / 3) + 1;
+    char base64_out[base64_length]; // If it causes issues, replace with 'alloca' on different platform
+
+    int base64_out_length;
+    if (EVP_EncodeUpdate(base64_encode_context_ptr.get(), reinterpret_cast<unsigned char*>(base64_out),
+                         &base64_out_length, bytes_str, base64_length) < 0) {
+        EVLOG_error << "Error during EVP_EncodeUpdate";
+        return false;
+    }
+
+    int encode_final_out;
+    EVP_EncodeFinal(base64_encode_context_ptr.get(), reinterpret_cast<unsigned char*>(base64_out), &encode_final_out);
+
+    out_encoded.clear();
+    out_encoded.insert(std::end(out_encoded), base64_out, base64_out + base64_out_length);
+
+    return true;
+}
+
+bool OpenSSLSupplier::base64_decode_to_bytes(const std::string& base64_string, std::vector<std::uint8_t>& out_decoded) {
+    return base64_decode<std::vector<std::uint8_t>>(base64_string, out_decoded);
+}
+
+bool OpenSSLSupplier::base64_decode_to_string(const std::string& base64_string, std::string& out_decoded) {
+    return base64_decode<std::string>(base64_string, out_decoded);
+}
+
+bool OpenSSLSupplier::base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes, std::string& out_encoded) {
+    return base64_encode(reinterpret_cast<const unsigned char*>(bytes.data()), bytes.size(), out_encoded);
+}
+
+bool OpenSSLSupplier::base64_encode_from_string(const std::string& string, std::string& out_encoded) {
+    return base64_encode(reinterpret_cast<const unsigned char*>(string.data()), string.size(), out_encoded);
 }
 
 } // namespace evse_security

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -398,12 +398,8 @@ DeleteCertificateResult EvseSecurity::delete_certificate(const CertificateHashDa
             X509CertificateBundle root_bundle(ca_bundle_path_map[load], EncodingFormat::PEM);
             X509CertificateBundle leaf_bundle(leaf_certificate_path, EncodingFormat::PEM);
 
-            auto full_list = root_bundle.split();
-            for (X509Wrapper& certif : leaf_bundle.split()) {
-                full_list.push_back(std::move(certif));
-            }
-
-            X509CertificateHierarchy hierarchy = X509CertificateHierarchy::build_hierarchy(full_list);
+            X509CertificateHierarchy hierarchy =
+                std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_bundle.split()));
 
             EVLOG_debug << "Delete hierarchy:(" << leaf_certificate_path.string() << ")\n"
                         << hierarchy.to_debug_string();
@@ -729,10 +725,9 @@ OCSPRequestDataList get_ocsp_request_data_internal(fs::path& root_path, std::vec
 
     try {
         std::vector<X509Wrapper> full_hierarchy = X509CertificateBundle(root_path, EncodingFormat::PEM).split();
-        std::move(std::begin(leaf_chain), std::end(leaf_chain), std::back_inserter(full_hierarchy));
 
         // Build the full hierarchy
-        auto hierarchy = X509CertificateHierarchy::build_hierarchy(full_hierarchy);
+        auto hierarchy = std::move(X509CertificateHierarchy::build_hierarchy(full_hierarchy, leaf_chain));
 
         // Search for the first valid root, and collect all the chain
         for (auto& root : hierarchy.get_hierarchy()) {
@@ -778,12 +773,18 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
                                      const std::string& ocsp_response) {
     std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
 
+    EVLOG_info << "Updating OCSP cache";
+
     // TODO(ioan): shouldn't we also do this for the MO?
     const auto ca_bundle_path = this->ca_bundle_path_map.at(CaCertificateType::V2G);
+    auto leaf_cert_dir = this->directories.secc_leaf_cert_directory; // V2G leafs
 
     try {
         X509CertificateBundle ca_bundle(ca_bundle_path, EncodingFormat::PEM);
-        auto& certificate_hierarchy = ca_bundle.get_certficate_hierarchy();
+        X509CertificateBundle leaf_bundle(leaf_cert_dir, EncodingFormat::PEM);
+
+        auto certificate_hierarchy =
+            std::move(X509CertificateHierarchy::build_hierarchy(ca_bundle.split(), leaf_bundle.split()));
 
         // TODO: If we already have the hash, over-write, else create a new one
         try {
@@ -798,7 +799,7 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
                     fs::create_directories(ocsp_path);
                 } else {
                     // Iterate existing hashes
-                    for (const auto& hash_entry : fs::recursive_directory_iterator(ocsp_path)) {
+                    for (const auto& hash_entry : fs::directory_iterator(ocsp_path)) {
                         if (hash_entry.is_regular_file()) {
                             CertificateHashData read_hash;
 
@@ -810,7 +811,8 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
                                 fs::path ocsp_path = hash_entry.path();
                                 ocsp_path.replace_extension(CERT_HASH_EXTENSION);
 
-                                std::ofstream fs(ocsp_path.c_str());
+                                // Discard previous content
+                                std::ofstream fs(ocsp_path.c_str(), std::ios::trunc);
                                 fs << ocsp_response;
                                 fs.close();
 
@@ -827,16 +829,17 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
                 const auto hash_file_path = ocsp_path / name / CERT_HASH_EXTENSION;
 
                 // Write out OCSP data
-                std::ofstream fs(ocsp_file_path.c_str());
-                fs << ocsp_response;
-                fs.close();
+                try {
+                    std::ofstream fs(ocsp_file_path.c_str());
+                    fs << ocsp_response;
+                    fs.close();
+                } catch (const std::exception& e) {
+                    EVLOG_error << "Could not write OCSP certificate data!";
+                }
 
-                // Write out the related hash
-                std::ofstream hs(hash_file_path.c_str());
-                hs << certificate_hash_data.issuer_name_hash;
-                hs << certificate_hash_data.issuer_key_hash;
-                hs << certificate_hash_data.serial_number;
-                hs.close();
+                if (false == filesystem_utils::write_hash_to_file(hash_file_path, certificate_hash_data)) {
+                    EVLOG_error << "Could not write OCSP certificate hash!";
+                }
 
                 EVLOG_debug << "OCSP certificate hash not found, written at path: " << ocsp_file_path;
             } else {
@@ -860,10 +863,14 @@ std::optional<std::string>
 EvseSecurity::retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data) {
     // TODO(ioan): shouldn't we also do this for the MO?
     const auto ca_bundle_path = this->ca_bundle_path_map.at(CaCertificateType::V2G);
+    const auto leaf_path = this->directories.secc_leaf_key_directory;
 
     try {
         X509CertificateBundle ca_bundle(ca_bundle_path, EncodingFormat::PEM);
-        auto& certificate_hierarchy = ca_bundle.get_certficate_hierarchy();
+        X509CertificateBundle leaf_bundle(leaf_path, EncodingFormat::PEM);
+
+        auto certificate_hierarchy =
+            std::move(X509CertificateHierarchy::build_hierarchy(ca_bundle.split(), leaf_bundle.split()));
 
         try {
             // Find the certificate
@@ -882,7 +889,7 @@ EvseSecurity::retrieve_ocsp_cache_internal(const CertificateHashData& certificat
                         if (filesystem_utils::read_hash_from_file(ocsp_entry.path(), read_hash) &&
                             (read_hash == certificate_hash_data)) {
                             fs::path replaced_ext = ocsp_entry.path();
-                            replaced_ext.replace_extension(".der");
+                            replaced_ext.replace_extension(DER_EXTENSION);
 
                             std::ifstream in_fs(replaced_ext.c_str());
                             std::string ocsp_response;
@@ -1024,18 +1031,23 @@ GetCertificateInfoResult EvseSecurity::get_leaf_certificate_info_internal(LeafCe
 
     fs::path key_dir;
     fs::path cert_dir;
+    CaCertificateType root_type;
 
     if (certificate_type == LeafCertificateType::CSMS) {
         key_dir = this->directories.csms_leaf_key_directory;
         cert_dir = this->directories.csms_leaf_cert_directory;
+        root_type = CaCertificateType::CSMS;
     } else if (certificate_type == LeafCertificateType::V2G) {
         key_dir = this->directories.secc_leaf_key_directory;
         cert_dir = this->directories.secc_leaf_cert_directory;
+        root_type = CaCertificateType::V2G;
     } else {
         EVLOG_warning << "Rejected attempt to retrieve non CSMS/V2G key pair";
         result.status = GetCertificateInfoStatus::Rejected;
         return result;
     }
+
+    fs::path root_dir = ca_bundle_path_map[root_type];
 
     // choose appropriate cert (valid_from / valid_to)
     try {
@@ -1102,7 +1114,10 @@ GetCertificateInfoResult EvseSecurity::get_leaf_certificate_info_internal(LeafCe
         fs::path chain_file;
 
         X509CertificateBundle leaf_directory(cert_dir, EncodingFormat::PEM);
-        auto& hierarchy = leaf_directory.get_certficate_hierarchy();
+        X509CertificateBundle root_bundle(root_dir, EncodingFormat::PEM); // Required for hierarchy
+
+        auto hierarchy =
+            std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_directory.split()));
 
         const std::vector<X509Wrapper>* leaf_fullchain = nullptr;
         const std::vector<X509Wrapper>* leaf_single = nullptr;
@@ -1509,12 +1524,12 @@ void EvseSecurity::garbage_collect() {
 
     EVLOG_info << "Starting garbage collect!";
 
-    std::vector<std::pair<fs::path, fs::path>> leaf_paths;
+    std::vector<std::tuple<fs::path, fs::path, CaCertificateType>> leaf_paths;
 
-    leaf_paths.push_back(
-        std::make_pair(this->directories.csms_leaf_cert_directory, this->directories.csms_leaf_key_directory));
-    leaf_paths.push_back(
-        std::make_pair(this->directories.secc_leaf_cert_directory, this->directories.secc_leaf_key_directory));
+    leaf_paths.push_back(std::make_tuple(this->directories.csms_leaf_cert_directory,
+                                         this->directories.csms_leaf_key_directory, CaCertificateType::CSMS));
+    leaf_paths.push_back(std::make_tuple(this->directories.secc_leaf_cert_directory,
+                                         this->directories.secc_leaf_key_directory, CaCertificateType::V2G));
 
     // Delete certificates first, give the option to cleanup the dangling keys afterwards
     std::set<fs::path> invalid_certificate_files;
@@ -1523,7 +1538,9 @@ void EvseSecurity::garbage_collect() {
     std::set<fs::path> protected_private_keys;
 
     // Order by latest valid, and keep newest with a safety limit
-    for (auto const& [cert_dir, key_dir] : leaf_paths) {
+    for (auto const& [cert_dir, key_dir, ca_type] : leaf_paths) {
+        // Root bundle required for hash of OCSP cache
+        X509CertificateBundle root_bundle(ca_bundle_path_map[ca_type], EncodingFormat::PEM);
         X509CertificateBundle expired_certs(cert_dir, EncodingFormat::PEM);
 
         // Only handle if we have more than the minimum certificates entry
@@ -1533,26 +1550,62 @@ void EvseSecurity::garbage_collect() {
 
             // Order by expiry date, and keep even expired certificates with a minimum of 10 certificates
             expired_certs.for_each_chain_ordered(
-                [this, &invalid_certificate_files, &skipped, &key_directory,
-                 &protected_private_keys](const fs::path& file, const std::vector<X509Wrapper>& chain) {
+                [this, &invalid_certificate_files, &skipped, &key_directory, &protected_private_keys,
+                 &root_bundle](const fs::path& file, const std::vector<X509Wrapper>& chain) {
                     // By default delete all empty
                     if (chain.size() <= 0) {
                         invalid_certificate_files.emplace(file);
                     }
 
                     if (++skipped > DEFAULT_MINIMUM_CERTIFICATE_ENTRIES) {
-                        // If the chain contains the first expired (leafs are the first)
-                        if (chain.size()) {
-                            if (chain[0].is_expired()) {
-                                invalid_certificate_files.emplace(file);
+                        if (chain.empty()) {
+                            return true;
+                        }
 
-                                // Also attempt to add the key for deletion
-                                try {
-                                    fs::path key_file = get_private_key_path_of_certificate(chain[0], key_directory,
-                                                                                            this->private_key_password);
-                                    invalid_certificate_files.emplace(key_file);
-                                } catch (NoPrivateKeyException& e) {
+                        // If the chain contains the first expired (leafs are the first)
+                        if (chain[0].is_expired()) {
+                            invalid_certificate_files.emplace(file);
+
+                            // Also attempt to add the key for deletion
+                            try {
+                                fs::path key_file = get_private_key_path_of_certificate(chain[0], key_directory,
+                                                                                        this->private_key_password);
+                                invalid_certificate_files.emplace(key_file);
+                            } catch (NoPrivateKeyException& e) {
+                            }
+
+                            auto leaf_chain = chain;
+                            X509CertificateHierarchy hierarchy =
+                                std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_chain));
+
+                            try {
+                                CertificateHashData ocsp_hash = hierarchy.get_certificate_hash(chain[0]);
+
+                                // Find OCSP cache with hash
+                                if (chain[0].get_file().has_value()) {
+                                    const auto ocsp_path = chain[0].get_file().value().parent_path() / "ocsp";
+
+                                    if (fs::exists(ocsp_path)) {
+                                        for (const auto& hash_entry : fs::directory_iterator(ocsp_path)) {
+                                            if (hash_entry.is_regular_file() == false) {
+                                                continue;
+                                            }
+                                            // Attempt hash read
+                                            CertificateHashData read_hash;
+
+                                            if (filesystem_utils::read_hash_from_file(hash_entry.path(), read_hash) &&
+                                                read_hash == ocsp_hash) {
+
+                                                auto oscp_data_path = hash_entry.path();
+                                                oscp_data_path.replace_extension(CERT_HASH_EXTENSION);
+
+                                                invalid_certificate_files.emplace(hash_entry.path());
+                                                invalid_certificate_files.emplace(oscp_data_path);
+                                            }
+                                        }
+                                    }
                                 }
+                            } catch (const NoCertificateFound& e) {
                             }
                         }
                     } else {
@@ -1597,7 +1650,7 @@ void EvseSecurity::garbage_collect() {
     // at a further invocation after the GC timer will elapse a few times. This behavior
     // was added so that if we have a reset and the CSMS sends us a CSR response while we were
     // down it should still be processed when we boot up and NOT delete the CSRs
-    for (auto const& [cert_dir, keys_dir] : leaf_paths) {
+    for (auto const& [cert_dir, keys_dir, ca_type] : leaf_paths) {
         fs::path cert_path = cert_dir;
         fs::path key_path = keys_dir;
 

--- a/lib/evse_security/evse_types.cpp
+++ b/lib/evse_security/evse_types.cpp
@@ -93,6 +93,17 @@ std::string hash_algorithm_to_string(HashAlgorithm e) {
     }
 };
 
+HashAlgorithm string_to_hash_algorithm(std::string s) {
+    if (s == "SHA256")
+        return HashAlgorithm::SHA256;
+    else if (s == "SHA384")
+        return HashAlgorithm::SHA384;
+    else if (s == "SHA512")
+        return HashAlgorithm::SHA512;
+
+    throw std::out_of_range("Could not convert string to HashAlgorithm");
+}
+
 std::string install_certificate_result_to_string(InstallCertificateResult e) {
     switch (e) {
     case InstallCertificateResult::InvalidSignature:

--- a/lib/evse_security/evse_types.cpp
+++ b/lib/evse_security/evse_types.cpp
@@ -142,20 +142,20 @@ std::string get_installed_certificates_status_to_string(GetInstalledCertificates
     }
 };
 
-std::string get_key_pair_status_to_string(GetKeyPairStatus e) {
+std::string get_key_pair_status_to_string(GetCertificateInfoStatus e) {
     switch (e) {
-    case GetKeyPairStatus::Accepted:
+    case GetCertificateInfoStatus::Accepted:
         return "Accepted";
-    case GetKeyPairStatus::Rejected:
+    case GetCertificateInfoStatus::Rejected:
         return "Rejected";
-    case GetKeyPairStatus::NotFound:
+    case GetCertificateInfoStatus::NotFound:
         return "NotFound";
-    case GetKeyPairStatus::NotFoundValid:
+    case GetCertificateInfoStatus::NotFoundValid:
         return "NotFoundValid";
-    case GetKeyPairStatus::PrivateKeyNotFound:
+    case GetCertificateInfoStatus::PrivateKeyNotFound:
         return "PrivateKeyNotFound";
     default:
-        throw std::out_of_range("Could not convert GetKeyPairStatus to string");
+        throw std::out_of_range("Could not convert GetCertificateInfoStatus to string");
     }
 };
 

--- a/lib/evse_security/evse_types.cpp
+++ b/lib/evse_security/evse_types.cpp
@@ -93,7 +93,7 @@ std::string hash_algorithm_to_string(HashAlgorithm e) {
     }
 };
 
-HashAlgorithm string_to_hash_algorithm(std::string s) {
+HashAlgorithm string_to_hash_algorithm(const std::string& s) {
     if (s == "SHA256")
         return HashAlgorithm::SHA256;
     else if (s == "SHA384")

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
+#include <evse_security/evse_types.hpp>
 #include <evse_security/utils/evse_filesystem.hpp>
 
 #include <fstream>
@@ -116,6 +117,27 @@ std::string get_random_file_name(const std::string& extension) {
          << distribution(generator) << extension;
 
     return buff.str();
+}
+
+bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_hash) {
+    if (file_path.extension() == CERT_HASH_EXTENSION) {
+        try {
+            std::ifstream hs(file_path);
+
+            hs >> out_hash.issuer_name_hash;
+            hs >> out_hash.issuer_key_hash;
+            hs >> out_hash.serial_number;
+
+            hs.close();
+
+            return true;
+        } catch (const std::exception& e) {
+            EVLOG_error << "Unknown error occurred while reading cert hash file: " << file_path;
+            return false;
+        }
+    }
+
+    return false;
 }
 
 } // namespace evse_security::filesystem_utils

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -140,4 +140,28 @@ bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_has
     return false;
 }
 
+bool write_hash_to_file(const fs::path& file_path, const CertificateHashData& hash) {
+    auto real_path = file_path;
+
+    if (file_path.has_extension() == false || file_path.extension() != CERT_HASH_EXTENSION) {
+        real_path.replace_extension(CERT_HASH_EXTENSION);
+    }
+
+    try {
+        // Write out the related hash
+        std::ofstream hs(real_path.c_str());
+        hs << hash.issuer_name_hash;
+        hs << hash.issuer_key_hash;
+        hs << hash.serial_number;
+        hs.close();
+
+        return true;
+    } catch (const std::exception& e) {
+        EVLOG_error << "Unknown error occurred writing cert hash file: " << file_path;
+        return false;
+    }
+
+    return false;
+}
+
 } // namespace evse_security::filesystem_utils

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -123,16 +123,19 @@ bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_has
     if (file_path.extension() == CERT_HASH_EXTENSION) {
         try {
             std::ifstream hs(file_path);
+            std::string algo;
 
+            hs >> algo;
             hs >> out_hash.issuer_name_hash;
             hs >> out_hash.issuer_key_hash;
             hs >> out_hash.serial_number;
-
             hs.close();
+
+            out_hash.hash_algorithm = conversions::string_to_hash_algorithm(algo);
 
             return true;
         } catch (const std::exception& e) {
-            EVLOG_error << "Unknown error occurred while reading cert hash file: " << file_path;
+            EVLOG_error << "Unknown error occurred while reading cert hash file: " << file_path << " err: " << e.what();
             return false;
         }
     }
@@ -150,14 +153,16 @@ bool write_hash_to_file(const fs::path& file_path, const CertificateHashData& ha
     try {
         // Write out the related hash
         std::ofstream hs(real_path.c_str());
-        hs << hash.issuer_name_hash;
-        hs << hash.issuer_key_hash;
-        hs << hash.serial_number;
+
+        hs << conversions::hash_algorithm_to_string(hash.hash_algorithm) << "\n";
+        hs << hash.issuer_name_hash << "\n";
+        hs << hash.issuer_key_hash << "\n";
+        hs << hash.serial_number << "\n";
         hs.close();
 
         return true;
     } catch (const std::exception& e) {
-        EVLOG_error << "Unknown error occurred writing cert hash file: " << file_path;
+        EVLOG_error << "Unknown error occurred writing cert hash file: " << file_path << " err: " << e.what();
         return false;
     }
 

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -73,7 +73,7 @@ bool write_to_file(const fs::path& file_path, const std::string& data, std::ios:
 }
 
 bool process_file(const fs::path& file_path, size_t buffer_size,
-                  std::function<bool(const std::byte*, std::size_t, bool last_chunk)>&& func) {
+                  std::function<bool(const std::uint8_t*, std::size_t, bool last_chunk)>&& func) {
     std::ifstream file(file_path, std::ios::binary);
 
     if (!file) {
@@ -81,7 +81,7 @@ bool process_file(const fs::path& file_path, size_t buffer_size,
         return false;
     }
 
-    std::vector<std::byte> buffer(buffer_size);
+    std::vector<std::uint8_t> buffer(buffer_size);
     bool interupted = false;
 
     while (file.read(reinterpret_cast<char*>(buffer.data()), buffer_size)) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -915,6 +915,22 @@ TEST_F(EvseSecurityTests, verify_expired_csr_deletion) {
     ASSERT_FALSE(fs::exists(csr_key_path));
 }
 
+TEST_F(EvseSecurityTests, verify_base64) {
+    std::string test_string1 = "U29tZSBkYXRhIGZvciB0ZXN0IGNhc2VzLiBTb21lIGRhdGEgZm9yIHRlc3QgY2FzZXMuIFNvbWUgZGF0YSBmb3I"
+                               "gdGVzdCBjYXNlcy4gU29tZSBkYXRhIGZvciB0ZXN0IGNhc2VzLg==";
+
+    std::string decoded = this->evse_security->base64_decode_to_string(test_string1);
+    ASSERT_EQ(
+        decoded,
+        std::string(
+            "Some data for test cases. Some data for test cases. Some data for test cases. Some data for test cases."));
+
+    std::string out_encoded = this->evse_security->base64_encode_from_string(decoded);
+    out_encoded.erase(std::remove(out_encoded.begin(), out_encoded.end(), '\n'), out_encoded.cend());
+
+    ASSERT_EQ(test_string1, out_encoded);
+}
+
 } // namespace evse_security
 
 // FIXME(piet): Add more tests for getRootCertificateHashData (incl. V2GCertificateChain etc.)

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -833,6 +833,8 @@ TEST_F(EvseSecurityTestsExpired, verify_expired_leaf_deletion) {
     // Garbage collect
     evse_security->garbage_collect();
 
+    // TODO: (ioan) test OCSP cache deletion
+
     // Ensure that we have 10 certificates, since we only keep 10, the newest
     {
         X509CertificateBundle full_certs(fs::path("certs/client/cso"), EncodingFormat::PEM);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -732,7 +732,8 @@ TEST_F(EvseSecurityTests, get_installed_certificates_and_delete_secc_leaf) {
 }
 
 TEST_F(EvseSecurityTests, leaf_cert_starts_in_future_accepted) {
-    const auto v2g_keypair_before = this->evse_security->get_key_pair(LeafCertificateType::V2G, EncodingFormat::PEM);
+    const auto v2g_keypair_before =
+        this->evse_security->get_leaf_certificate_info(LeafCertificateType::V2G, EncodingFormat::PEM);
 
     const auto new_root_ca = read_file_to_string(std::filesystem::path("future_leaf/V2G_ROOT_CA.pem"));
     const auto result_ca = this->evse_security->install_ca_certificate(new_root_ca, CaCertificateType::V2G);
@@ -747,10 +748,11 @@ TEST_F(EvseSecurityTests, leaf_cert_starts_in_future_accepted) {
     ASSERT_TRUE(result_client == InstallCertificateResult::Accepted);
 
     // Check: The certificate is installed, but it isn't actually used
-    const auto v2g_keypair_after = this->evse_security->get_key_pair(LeafCertificateType::V2G, EncodingFormat::PEM);
-    ASSERT_EQ(v2g_keypair_after.pair.value().certificate, v2g_keypair_before.pair.value().certificate);
-    ASSERT_EQ(v2g_keypair_after.pair.value().key, v2g_keypair_before.pair.value().key);
-    ASSERT_EQ(v2g_keypair_after.pair.value().password, v2g_keypair_before.pair.value().password);
+    const auto v2g_keypair_after =
+        this->evse_security->get_leaf_certificate_info(LeafCertificateType::V2G, EncodingFormat::PEM);
+    ASSERT_EQ(v2g_keypair_after.info.value().certificate, v2g_keypair_before.info.value().certificate);
+    ASSERT_EQ(v2g_keypair_after.info.value().key, v2g_keypair_before.info.value().key);
+    ASSERT_EQ(v2g_keypair_after.info.value().password, v2g_keypair_before.info.value().password);
 }
 
 TEST_F(EvseSecurityTests, expired_leaf_cert_rejected) {


### PR DESCRIPTION
## Describe your changes

- Fixed a certificate hierarchy potential issue when creating the OCSP cache
- Added possibility to retrieve the OCSP cache
- Added base64 utilities

## Issue ticket number and link

https://github.com/EVerest/libocpp/pull/596

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

