### PR TITLE
Bugfix/certificate cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(everest-evse_security VERSION 0.5
+project(everest-evse_security VERSION 0.6
         DESCRIPTION "Implementation of EVSE related security operations"
 		LANGUAGES CXX C
 )

--- a/include/evse_security/crypto/interface/crypto_supplier.hpp
+++ b/include/evse_security/crypto/interface/crypto_supplier.hpp
@@ -64,8 +64,8 @@ public: // X509 certificate utilities
                                                                      const std::optional<fs::path> file_path);
 
     /// @brief Checks if the private key is consistent with the provided handle
-    static bool x509_check_private_key(X509Handle* handle, std::string private_key,
-                                       std::optional<std::string> password);
+    static KeyValidationResult x509_check_private_key(X509Handle* handle, std::string private_key,
+                                                      std::optional<std::string> password);
 
     /// @brief Verifies the signature with the certificate handle public key against the data
     static bool x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,

--- a/include/evse_security/crypto/interface/crypto_types.hpp
+++ b/include/evse_security/crypto/interface/crypto_types.hpp
@@ -18,6 +18,13 @@ enum class CryptoKeyType {
     RSA_7680,      // Protection lifetime: >2031
 };
 
+enum class KeyValidationResult {
+    Valid,
+    KeyLoadFailure, // The key could not be loaded, might be an password or invalid string
+    Invalid,        // The key is not linked to the specified certificate
+    Unknown,        // Unknown error, not related to provider validation
+};
+
 struct KeyGenerationInfo {
     CryptoKeyType key_type;
 

--- a/include/evse_security/crypto/openssl/openssl_supplier.hpp
+++ b/include/evse_security/crypto/openssl/openssl_supplier.hpp
@@ -36,8 +36,8 @@ public:
                                                                      bool allow_future_certificates,
                                                                      const std::optional<fs::path> dir_path,
                                                                      const std::optional<fs::path> file_path);
-    static bool x509_check_private_key(X509Handle* handle, std::string private_key,
-                                       std::optional<std::string> password);
+    static KeyValidationResult x509_check_private_key(X509Handle* handle, std::string private_key,
+                                                      std::optional<std::string> password);
     static bool x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
                                       const std::vector<std::byte>& data);
 

--- a/include/evse_security/crypto/openssl/openssl_tpm.hpp
+++ b/include/evse_security/crypto/openssl/openssl_tpm.hpp
@@ -9,6 +9,8 @@
 #include <mutex>
 #include <string>
 
+#include <evse_security/utils/evse_filesystem_types.hpp>
+
 // opaque types (from OpenSSL)
 struct ossl_lib_ctx_st;  // OpenSSL OSSL_LIB_CTX;
 struct ossl_provider_st; // OpenSSL OSSL_PROVIDER
@@ -25,7 +27,7 @@ bool is_tpm_key_string(const std::string& private_key_pem);
 /// @param private_key_file_pem filename of the PEM file
 /// @return true when file starts "-----BEGIN TSS2 PRIVATE KEY-----"
 /// @note works irrespective of OpenSSL version
-bool is_tpm_key_filename(const std::string& private_key_file_pem);
+bool is_tpm_key_file(const fs::path& private_key_file_pem);
 
 /// @brief Manage the loading and configuring of OpenSSL providers
 ///

--- a/lib/evse_security/crypto/interface/crypto_supplier.cpp
+++ b/lib/evse_security/crypto/interface/crypto_supplier.cpp
@@ -81,9 +81,9 @@ CertificateValidationResult AbstractCryptoSupplier::x509_verify_certificate_chai
     default_crypto_supplier_usage_error() return CertificateValidationResult::Unknown;
 }
 
-bool AbstractCryptoSupplier::x509_check_private_key(X509Handle* handle, std::string private_key,
-                                                    std::optional<std::string> password) {
-    default_crypto_supplier_usage_error() return false;
+KeyValidationResult AbstractCryptoSupplier::x509_check_private_key(X509Handle* handle, std::string private_key,
+                                                                   std::optional<std::string> password) {
+    default_crypto_supplier_usage_error() return KeyValidationResult::Unknown;
 }
 
 bool AbstractCryptoSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,

--- a/lib/evse_security/crypto/openssl/openssl_supplier.cpp
+++ b/lib/evse_security/crypto/openssl/openssl_supplier.cpp
@@ -631,7 +631,7 @@ KeyValidationResult OpenSSLSupplier::x509_check_private_key(X509Handle* handle, 
     } else {
         provider.set_global_mode(OpenSSLProvider::mode_t::default_provider);
     }
-    EVLOG_info << "TPM Key: " << tpm_key;
+    EVLOG_debug << "TPM Key: " << tpm_key;
 
     BIO_ptr bio(BIO_new_mem_buf(private_key.c_str(), -1));
     // Passing password string since if NULL is provided, the password CB will be called

--- a/lib/evse_security/crypto/openssl/openssl_tpm.cpp
+++ b/lib/evse_security/crypto/openssl/openssl_tpm.cpp
@@ -29,12 +29,17 @@ bool is_tpm_key_string(const std::string& private_key_pem) {
     return private_key_pem.find("-----BEGIN TSS2 PRIVATE KEY-----") != std::string::npos;
 }
 
-bool is_tpm_key_filename(const std::string& private_key_file_pem) {
-    std::ifstream key_file(private_key_file_pem);
-    std::string line;
-    std::getline(key_file, line);
-    key_file.close();
-    return line == "-----BEGIN TSS2 PRIVATE KEY-----";
+bool is_tpm_key_file(const fs::path& private_key_file_pem) {
+    if (fs::is_regular_file(private_key_file_pem)) {
+        std::ifstream key_file(private_key_file_pem);
+        std::string line;
+        std::getline(key_file, line);
+        key_file.close();
+
+        return line.find("-----BEGIN TSS2 PRIVATE KEY-----") != std::string::npos;
+    }
+
+    return false;
 }
 
 #ifdef USING_OPENSSL_3_TPM

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -949,7 +949,7 @@ GetKeyPairResult EvseSecurity::get_key_pair_internal(LeafCertificateType certifi
         leaf_certificates.for_each_chain_ordered(
             [&](const fs::path& file, const std::vector<X509Wrapper>& chain) {
                 // Search for the first valid where we can find a key
-                if (chain.size() && chain.at(0).is_valid()) {
+                if (not chain.empty() && chain.at(0).is_valid()) {
                     try {
                         // Search for the private key
                         auto priv_key_path =
@@ -969,7 +969,7 @@ GetKeyPairResult EvseSecurity::get_key_pair_internal(LeafCertificateType certifi
             },
             [](const std::vector<X509Wrapper>& a, const std::vector<X509Wrapper>& b) {
                 // Order from newest to oldest
-                if (a.size() && b.size()) {
+                if (not a.empty() && not b.empty()) {
                     return a.at(0).get_valid_to() > b.at(0).get_valid_to();
                 } else {
                     return false;

--- a/tests/openssl_supplier_test.cpp
+++ b/tests/openssl_supplier_test.cpp
@@ -80,7 +80,7 @@ TEST_F(OpenSSLSupplierTest, x509_check_private_key) {
     auto cert = res_leaf[0].get();
     auto key = getFile("pki/server_priv.pem");
     auto res = OpenSSLSupplier::x509_check_private_key(cert, key, std::nullopt);
-    ASSERT_TRUE(res);
+    ASSERT_TRUE(res == KeyValidationResult::Valid);
 }
 
 TEST_F(OpenSSLSupplierTest, x509_verify_certificate_chain) {


### PR DESCRIPTION
## Describe your changes

This PR fixes a bug in the certificate cleanup that was not keeping certificate keys when cleaning up. Now the keys are also kept.

## Issue ticket number and link

Libocpp pull: https://github.com/EVerest/libocpp/pull/583

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

