### PR TITLE
Bugfix/66 gracefull crash handling

### DIFF
--- a/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/include/evse_security/certificate/x509_hierarchy.hpp
@@ -2,6 +2,7 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <algorithm>
 #include <queue>
 
 #include <evse_security/certificate/x509_wrapper.hpp>
@@ -109,6 +110,19 @@ public:
     /// @brief Builds a proper certificate hierarchy from the provided certificates. The
     /// hierarchy can be incomplete, in case orphan certificates are present in the list
     static X509CertificateHierarchy build_hierarchy(std::vector<X509Wrapper>& certificates);
+
+    template <typename... Args> static X509CertificateHierarchy build_hierarchy(Args... certificates) {
+        X509CertificateHierarchy ordered;
+
+        (std::for_each(certificates.begin(), certificates.end(),
+                       [&ordered](X509Wrapper& cert) { ordered.insert(std::move(cert)); }),
+         ...); // Fold expr
+
+        // Prune the tree
+        ordered.prune();
+
+        return ordered;
+    }
 
 private:
     /// @brief Inserts the certificate in the hierarchy. If it is not a root

--- a/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/include/evse_security/certificate/x509_hierarchy.hpp
@@ -60,6 +60,10 @@ public:
     /// @brief Searches for the provided hash, throwing a NoCertificateFound if not found
     X509Wrapper find_certificate(const CertificateHashData& hash);
 
+    /// @brief Searches for all the certificates with the provided hash, throwing a NoCertificateFound
+    // if none were found. Can be useful when we have SUB-CAs in multiple bundles
+    std::vector<X509Wrapper> find_certificates_multi(const CertificateHashData& hash);
+
 public:
     std::string to_debug_string();
 

--- a/include/evse_security/certificate/x509_wrapper.hpp
+++ b/include/evse_security/certificate/x509_wrapper.hpp
@@ -21,11 +21,6 @@ enum class X509CertificateSource {
     STRING
 };
 
-const fs::path PEM_EXTENSION = ".pem";
-const fs::path DER_EXTENSION = ".der";
-const fs::path KEY_EXTENSION = ".key";
-const fs::path TPM_KEY_EXTENSION = ".tkey";
-
 /// @brief Convenience wrapper around openssl X509 certificate
 class X509Wrapper {
 public:

--- a/include/evse_security/crypto/interface/crypto_supplier.hpp
+++ b/include/evse_security/crypto/interface/crypto_supplier.hpp
@@ -71,7 +71,8 @@ public: // X509 certificate utilities
                                       const std::vector<std::uint8_t>& data);
 
     /// @brief Generates a certificate signing request with the provided parameters
-    static bool x509_generate_csr(const CertificateSigningRequestInfo& generation_info, std::string& out_csr);
+    static CertificateSignRequestResult x509_generate_csr(const CertificateSigningRequestInfo& generation_info,
+                                                          std::string& out_csr);
 
 public: // Digesting/decoding utils
     static bool digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest);

--- a/include/evse_security/crypto/interface/crypto_supplier.hpp
+++ b/include/evse_security/crypto/interface/crypto_supplier.hpp
@@ -67,15 +67,20 @@ public: // X509 certificate utilities
                                                       std::optional<std::string> password);
 
     /// @brief Verifies the signature with the certificate handle public key against the data
-    static bool x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
-                                      const std::vector<std::byte>& data);
+    static bool x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
+                                      const std::vector<std::uint8_t>& data);
 
     /// @brief Generates a certificate signing request with the provided parameters
     static bool x509_generate_csr(const CertificateSigningRequestInfo& generation_info, std::string& out_csr);
 
 public: // Digesting/decoding utils
-    static bool digest_file_sha256(const fs::path& path, std::vector<std::byte>& out_digest);
-    static bool decode_base64_signature(const std::string& signature, std::vector<std::byte>& out_decoded);
+    static bool digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest);
+
+    static bool base64_decode_to_bytes(const std::string& base64_string, std::vector<std::uint8_t>& out_decoded);
+    static bool base64_decode_to_string(const std::string& base64_string, std::string& out_decoded);
+
+    static bool base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes, std::string& out_encoded);
+    static bool base64_encode_from_string(const std::string& string, std::string& out_encoded);
 };
 
 } // namespace evse_security

--- a/include/evse_security/crypto/interface/crypto_supplier.hpp
+++ b/include/evse_security/crypto/interface/crypto_supplier.hpp
@@ -43,7 +43,7 @@ public: // X509 certificate utilities
     /// (not yet valid)
     /// @param out_valid_to Valid amount of seconds. A negative value is in the past (expired), a positive one is in the
     /// future
-    static void x509_get_validity(X509Handle* handle, std::int64_t& out_valid_in, std::int64_t& out_valid_to);
+    static bool x509_get_validity(X509Handle* handle, std::int64_t& out_valid_in, std::int64_t& out_valid_to);
 
     static bool x509_is_selfsigned(X509Handle* handle);
     static bool x509_is_child(X509Handle* child, X509Handle* parent);

--- a/include/evse_security/crypto/interface/crypto_types.hpp
+++ b/include/evse_security/crypto/interface/crypto_types.hpp
@@ -15,7 +15,7 @@ enum class CryptoKeyType {
     EC_secp384r1,  // P-384, ~equiv to rsa 7680
     RSA_TPM20,     // Default TPM RSA, only option allowed for TPM (universal support), 2048 bits
     RSA_3072,      // Default RSA. Protection lifetime: ~2030
-    RSA_7680,      // Protection lifetime: >2031
+    RSA_7680,      // Protection lifetime: >2031. Very long generation time 8-40s on 16 core PC
 };
 
 enum class KeyValidationResult {

--- a/include/evse_security/crypto/interface/crypto_types.hpp
+++ b/include/evse_security/crypto/interface/crypto_types.hpp
@@ -25,6 +25,16 @@ enum class KeyValidationResult {
     Unknown,        // Unknown error, not related to provider validation
 };
 
+enum class CertificateSignRequestResult {
+    Valid,
+    KeyGenerationError, // Error when generating the key, maybe invalid key type
+    VersioningError,    // The version could not be set
+    PubkeyError,        // The public key could not be attached
+    ExtensionsError,    // The extensions could not be appended
+    SigningError,       // The CSR could not be signed, maybe key or signing algo invalid
+    Unknown,            // Any other error
+};
+
 struct KeyGenerationInfo {
     CryptoKeyType key_type;
 
@@ -76,5 +86,9 @@ using KeyHandle_ptr = std::unique_ptr<KeyHandle>;
 
 // Transforms a duration of days into seconds
 using days_to_seconds = std::chrono::duration<std::int64_t, std::ratio<86400>>;
+
+namespace conversions {
+std::string get_certificate_sign_request_result_to_string(CertificateSignRequestResult e);
+}
 
 } // namespace evse_security

--- a/include/evse_security/crypto/openssl/openssl_supplier.hpp
+++ b/include/evse_security/crypto/openssl/openssl_supplier.hpp
@@ -37,14 +37,19 @@ public:
                                   const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path);
     static KeyValidationResult x509_check_private_key(X509Handle* handle, std::string private_key,
                                                       std::optional<std::string> password);
-    static bool x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
-                                      const std::vector<std::byte>& data);
+    static bool x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
+                                      const std::vector<std::uint8_t>& data);
 
     static bool x509_generate_csr(const CertificateSigningRequestInfo& csr_info, std::string& out_csr);
 
 public:
-    static bool digest_file_sha256(const fs::path& path, std::vector<std::byte>& out_digest);
-    static bool decode_base64_signature(const std::string& signature, std::vector<std::byte>& out_decoded);
+    static bool digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest);
+
+    static bool base64_decode_to_bytes(const std::string& base64_string, std::vector<std::uint8_t>& out_decoded);
+    static bool base64_decode_to_string(const std::string& base64_string, std::string& out_decoded);
+
+    static bool base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes, std::string& out_encoded);
+    static bool base64_encode_from_string(const std::string& string, std::string& out_encoded);
 };
 
 } // namespace evse_security

--- a/include/evse_security/crypto/openssl/openssl_supplier.hpp
+++ b/include/evse_security/crypto/openssl/openssl_supplier.hpp
@@ -40,7 +40,8 @@ public:
     static bool x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
                                       const std::vector<std::uint8_t>& data);
 
-    static bool x509_generate_csr(const CertificateSigningRequestInfo& csr_info, std::string& out_csr);
+    static CertificateSignRequestResult x509_generate_csr(const CertificateSigningRequestInfo& csr_info,
+                                                          std::string& out_csr);
 
 public:
     static bool digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest);

--- a/include/evse_security/crypto/openssl/openssl_supplier.hpp
+++ b/include/evse_security/crypto/openssl/openssl_supplier.hpp
@@ -26,7 +26,7 @@ public:
     static std::string x509_get_serial_number(X509Handle* handle);
     static std::string x509_get_issuer_name_hash(X509Handle* handle);
     static std::string x509_get_common_name(X509Handle* handle);
-    static void x509_get_validity(X509Handle* handle, std::int64_t& out_valid_in, std::int64_t& out_valid_to);
+    static bool x509_get_validity(X509Handle* handle, std::int64_t& out_valid_in, std::int64_t& out_valid_to);
     static bool x509_is_selfsigned(X509Handle* handle);
     static bool x509_is_child(X509Handle* child, X509Handle* parent);
     static bool x509_is_equal(X509Handle* a, X509Handle* b);

--- a/include/evse_security/detail/openssl/openssl_types.hpp
+++ b/include/evse_security/detail/openssl/openssl_types.hpp
@@ -5,6 +5,8 @@
 #include <memory>
 #include <openssl/x509v3.h>
 
+#define EVSE_OPENSSL_VER_3 (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+
 template <> class std::default_delete<X509> {
 public:
     void operator()(X509* ptr) const {
@@ -54,20 +56,6 @@ public:
     }
 };
 
-template <> class std::default_delete<EC_KEY> {
-public:
-    void operator()(EC_KEY* ptr) const {
-        ::EC_KEY_free(ptr);
-    }
-};
-
-template <> class std::default_delete<RSA> {
-public:
-    void operator()(RSA* ptr) const {
-        ::RSA_free(ptr);
-    }
-};
-
 template <> class std::default_delete<BIO> {
 public:
     void operator()(BIO* ptr) const {
@@ -89,6 +77,22 @@ public:
     }
 };
 
+#if !EVSE_OPENSSL_VER_3
+template <> class std::default_delete<EC_KEY> {
+public:
+    void operator()(EC_KEY* ptr) const {
+        ::EC_KEY_free(ptr);
+    }
+};
+
+template <> class std::default_delete<RSA> {
+public:
+    void operator()(RSA* ptr) const {
+        ::RSA_free(ptr);
+    }
+};
+#endif
+
 namespace evse_security {
 
 using X509_ptr = std::unique_ptr<X509>;
@@ -100,10 +104,13 @@ using X509_STACK_UNSAFE_ptr = std::unique_ptr<STACK_OF(X509)>;
 using X509_REQ_ptr = std::unique_ptr<X509_REQ>;
 using EVP_PKEY_ptr = std::unique_ptr<EVP_PKEY>;
 using EVP_PKEY_CTX_ptr = std::unique_ptr<EVP_PKEY_CTX>;
-using EC_KEY_ptr = std::unique_ptr<EC_KEY>;
-using RSA_ptr = std::unique_ptr<RSA>;
 using BIO_ptr = std::unique_ptr<BIO>;
 using EVP_MD_CTX_ptr = std::unique_ptr<EVP_MD_CTX>;
 using EVP_ENCODE_CTX_ptr = std::unique_ptr<EVP_ENCODE_CTX>;
+
+#if !EVSE_OPENSSL_VER_3
+using EC_KEY_ptr = std::unique_ptr<EC_KEY>;
+using RSA_ptr = std::unique_ptr<RSA>;
+#endif
 
 } // namespace evse_security

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -142,6 +142,11 @@ public:
     /// @param ocsp_response the actual OCSP data
     void update_ocsp_cache(const CertificateHashData& certificate_hash_data, const std::string& ocsp_response);
 
+    /// @brief Retrieves from the OCSP cache for the given \p certificate_hash_data
+    /// @param certificate_hash_data identifies the certificate for which the \p ocsp_response is specified
+    /// @return the actual OCSP data or an exception is thrown if no data is found
+    std::optional<std::string> retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data);
+
     /// @brief Indicates if a CA certificate for the given \p certificate_type is installed on the filesystem
     /// Supports both CA certificate bundles and directories
     /// @param certificate_type

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -142,10 +142,11 @@ public:
     /// @param ocsp_response the actual OCSP data
     void update_ocsp_cache(const CertificateHashData& certificate_hash_data, const std::string& ocsp_response);
 
+    // TODO: Switch to path
     /// @brief Retrieves from the OCSP cache for the given \p certificate_hash_data
     /// @param certificate_hash_data identifies the certificate for which the \p ocsp_response is specified
     /// @return the actual OCSP data or an empty value
-    std::optional<std::string> retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data);
+    std::optional<fs::path> retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data);
 
     /// @brief Indicates if a CA certificate for the given \p certificate_type is installed on the filesystem
     /// Supports both CA certificate bundles and directories
@@ -247,7 +248,7 @@ private:
                                                             LeafCertificateType certificate_type);
     GetCertificateInfoResult get_leaf_certificate_info_internal(LeafCertificateType certificate_type,
                                                                 EncodingFormat encoding, bool include_ocsp = false);
-    std::optional<std::string> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
+    std::optional<fs::path> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
     bool is_ca_certificate_installed_internal(CaCertificateType certificate_type);
 
     /// @brief Determines if the total filesize of certificates is > than the max_filesystem_usage bytes
@@ -287,6 +288,7 @@ private:
     FRIEND_TEST(EvseSecurityTests, verify_full_filesystem_install_reject);
     FRIEND_TEST(EvseSecurityTests, verify_full_filesystem);
     FRIEND_TEST(EvseSecurityTests, verify_expired_csr_deletion);
+    FRIEND_TEST(EvseSecurityTests, verify_ocsp_garbage_collect);
     FRIEND_TEST(EvseSecurityTestsExpired, verify_expired_leaf_deletion);
 #endif
 };

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -219,6 +219,26 @@ public:
     static bool verify_file_signature(const fs::path& path, const std::string& signing_certificate,
                                       const std::string signature);
 
+    /// @brief Decodes the base64 encoded string to the raw byte representation
+    /// @param base64_string base64 encoded string
+    /// @return decoded byte vector
+    static std::vector<std::uint8_t> base64_decode_to_bytes(const std::string& base64_string);
+
+    /// @brief Decodes the base64 encoded string to string representation
+    /// @param base64_string base64 encoded string
+    /// @return decoded string array
+    static std::string base64_decode_to_string(const std::string& base64_string);
+
+    /// @brief Encodes the raw bytes to a base64 string
+    /// @param decoded_bytes raw byte array
+    /// @return encoded base64 string
+    static std::string base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes);
+
+    /// @brief Encodes the string containing raw bytes to a base64 string
+    /// @param decoded_bytes string containing raw bytes
+    /// @return encoded base64 string
+    static std::string base64_encode_from_string(const std::string& string);
+
 private:
     // Internal versions of the functions do not lock the mutex
     CertificateValidationResult verify_certificate_internal(const std::string& certificate_chain,

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -186,8 +186,10 @@ public:
     /// the leaf including any possible SUBCAs
     /// @param certificate_type type of the leaf certificate
     /// @param encoding specifies PEM or DER format
+    /// @param include_ocsp if OCSP data should be included
     /// @return contains response result
-    GetKeyPairResult get_key_pair(LeafCertificateType certificate_type, EncodingFormat encoding);
+    GetCertificateInfoResult get_leaf_certificate_info(LeafCertificateType certificate_type, EncodingFormat encoding,
+                                                       bool include_ocsp = false);
 
     /// @brief Checks and updates the symlinks for the V2G leaf certificates and keys to the most recent valid one
     /// @return true if one of the links was updated
@@ -243,7 +245,9 @@ private:
     // Internal versions of the functions do not lock the mutex
     CertificateValidationResult verify_certificate_internal(const std::string& certificate_chain,
                                                             LeafCertificateType certificate_type);
-    GetKeyPairResult get_key_pair_internal(LeafCertificateType certificate_type, EncodingFormat encoding);
+    GetCertificateInfoResult get_leaf_certificate_info_internal(LeafCertificateType certificate_type,
+                                                                EncodingFormat encoding, bool include_ocsp = false);
+    std::optional<std::string> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
     bool is_ca_certificate_installed_internal(CaCertificateType certificate_type);
 
     /// @brief Determines if the total filesize of certificates is > than the max_filesystem_usage bytes

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -165,10 +165,11 @@ public:
     /// @param organization
     /// @param common
     /// @param use_tpm  If the TPM should be used for the CSR request
-    /// @return the PEM formatted certificate signing request
-    std::string generate_certificate_signing_request(LeafCertificateType certificate_type, const std::string& country,
-                                                     const std::string& organization, const std::string& common,
-                                                     bool use_tpm);
+    /// @return the status and an optional PEM formatted certificate signing request string
+    GetCertificateSignRequestResult generate_certificate_signing_request(LeafCertificateType certificate_type,
+                                                                         const std::string& country,
+                                                                         const std::string& organization,
+                                                                         const std::string& common, bool use_tpm);
 
     /// @brief Generates a certificate signing request for the given \p certificate_type , \p country , \p organization
     /// and \p common without using the TPM
@@ -176,9 +177,11 @@ public:
     /// @param country
     /// @param organization
     /// @param common
-    /// @return the PEM formatted certificate signing request
-    std::string generate_certificate_signing_request(LeafCertificateType certificate_type, const std::string& country,
-                                                     const std::string& organization, const std::string& common);
+    /// @return the status and an optional PEM formatted certificate signing request string
+    GetCertificateSignRequestResult generate_certificate_signing_request(LeafCertificateType certificate_type,
+                                                                         const std::string& country,
+                                                                         const std::string& organization,
+                                                                         const std::string& common);
 
     /// @brief Searches the filesystem on the specified directories for the given \p certificate_type and retrieves the
     /// most recent certificate that is already valid and the respective key.  If no certificate is present or no key is
@@ -202,6 +205,9 @@ public:
     /// @param certificate_type
     /// @return CA certificate file
     std::string get_verify_file(CaCertificateType certificate_type);
+
+    /// @brief An extension of 'get_verify_file' with error handling included
+    GetCertificateInfoResult get_ca_certificate_info(CaCertificateType certificate_type);
 
     /// @brief Gets the expiry day count for the leaf certificate of the given \p certificate_type
     /// @param certificate_type
@@ -248,8 +254,13 @@ private:
                                                             LeafCertificateType certificate_type);
     GetCertificateInfoResult get_leaf_certificate_info_internal(LeafCertificateType certificate_type,
                                                                 EncodingFormat encoding, bool include_ocsp = false);
+    GetCertificateInfoResult get_ca_certificate_info_internal(CaCertificateType certificate_type);
     std::optional<fs::path> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
     bool is_ca_certificate_installed_internal(CaCertificateType certificate_type);
+
+    GetCertificateSignRequestResult
+    generate_certificate_signing_request_internal(LeafCertificateType certificate_type,
+                                                  const CertificateSigningRequestInfo& info);
 
     /// @brief Determines if the total filesize of certificates is > than the max_filesystem_usage bytes
     bool is_filesystem_full();

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -191,7 +191,7 @@ public:
     /// @param certificate_type type of the leaf certificate
     /// @param encoding specifies PEM or DER format
     /// @param include_ocsp if OCSP data should be included
-    /// @return contains response result
+    /// @return contains response result, with info related to the certificate chain and response status
     GetCertificateInfoResult get_leaf_certificate_info(LeafCertificateType certificate_type, EncodingFormat encoding,
                                                        bool include_ocsp = false);
 

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -144,7 +144,7 @@ public:
 
     /// @brief Retrieves from the OCSP cache for the given \p certificate_hash_data
     /// @param certificate_hash_data identifies the certificate for which the \p ocsp_response is specified
-    /// @return the actual OCSP data or an exception is thrown if no data is found
+    /// @return the actual OCSP data or an empty value
     std::optional<std::string> retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data);
 
     /// @brief Indicates if a CA certificate for the given \p certificate_type is installed on the filesystem

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -76,7 +76,7 @@ enum class GetInstalledCertificatesStatus {
     NotFound,
 };
 
-enum class GetKeyPairStatus {
+enum class GetCertificateInfoStatus {
     Accepted,
     Rejected,
     NotFound,
@@ -123,15 +123,25 @@ struct OCSPRequestData {
 struct OCSPRequestDataList {
     std::vector<OCSPRequestData> ocsp_request_data_list; ///< A list of OCSP request data
 };
-struct KeyPair {
-    fs::path key;                        ///< The path of the PEM or DER encoded private key
-    fs::path certificate;                ///< The path of the PEM or DER encoded certificate chain
-    fs::path certificate_single;         ///< The path of the PEM or DER encoded certificate
-    std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
+
+struct CertificateOCSP {
+    CertificateHashData hash;
+    std::optional<fs::path> oscsp_data;
 };
-struct GetKeyPairResult {
-    GetKeyPairStatus status;
-    std::optional<KeyPair> pair;
+
+struct CertificateInfo {
+    fs::path key;                               ///< The path of the PEM or DER encoded private key
+    std::optional<fs::path> certificate;        ///< The path of the PEM or DER encoded certificate chain if found
+    std::optional<fs::path> certificate_single; ///< The path of the PEM or DER encoded certificate if found
+    int certificate_count; ///< The count of certificates in the chain, if the chain is available, or if single 1
+    std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
+    std::vector<CertificateOCSP>
+        oscsp; ///< Contains the ordered list of OCSP certificate data based on the chain file order
+};
+
+struct GetCertificateInfoResult {
+    GetCertificateInfoStatus status;
+    std::optional<CertificateInfo> info;
 };
 
 namespace conversions {
@@ -144,7 +154,7 @@ std::string hash_algorithm_to_string(HashAlgorithm e);
 std::string install_certificate_result_to_string(InstallCertificateResult e);
 std::string delete_certificate_result_to_string(DeleteCertificateResult e);
 std::string get_installed_certificates_status_to_string(GetInstalledCertificatesStatus e);
-std::string get_key_pair_status_to_string(GetKeyPairStatus e);
+std::string get_certificate_info_status_to_string(GetCertificateInfoStatus e);
 } // namespace conversions
 
 } // namespace evse_security

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -90,6 +90,13 @@ enum class GetCertificateInfoStatus {
     PrivateKeyNotFound,
 };
 
+enum class GetCertificateSignRequestStatus {
+    Accepted,
+    InvalidRequestedType, ///< Requested a CSR for non CSMS/V2G leafs
+    KeyGenError,          ///< The key could not be generated with the requested/default parameters
+    GenerationError,      ///< Any other error when creating the CSR
+};
+
 // types of evse_security
 
 struct CertificateHashData {
@@ -148,6 +155,12 @@ struct GetCertificateInfoResult {
     GetCertificateInfoStatus status;
     std::optional<CertificateInfo> info;
 };
+
+struct GetCertificateSignRequestResult {
+    GetCertificateSignRequestStatus status;
+    std::optional<std::string> csr;
+};
+
 namespace conversions {
 std::string encoding_format_to_string(EncodingFormat e);
 std::string ca_certificate_type_to_string(CaCertificateType e);

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -10,6 +10,12 @@
 
 namespace evse_security {
 
+const fs::path PEM_EXTENSION = ".pem";
+const fs::path DER_EXTENSION = ".der";
+const fs::path KEY_EXTENSION = ".key";
+const fs::path TPM_KEY_EXTENSION = ".tkey";
+const fs::path CERT_HASH_EXTENSION = ".hash";
+
 enum class EncodingFormat {
     DER,
     PEM,
@@ -125,8 +131,8 @@ struct OCSPRequestDataList {
 };
 
 struct CertificateOCSP {
-    CertificateHashData hash;
-    std::optional<std::string> oscsp_data;
+    CertificateHashData hash;          ///< Hash of the certificate for which the OCSP data is held
+    std::optional<fs::path> ocsp_path; ///< Path to the file in which the certificate OCSP data is held
 };
 
 struct CertificateInfo {
@@ -142,13 +148,6 @@ struct GetCertificateInfoResult {
     GetCertificateInfoStatus status;
     std::optional<CertificateInfo> info;
 };
-
-const fs::path PEM_EXTENSION = ".pem";
-const fs::path DER_EXTENSION = ".der";
-const fs::path KEY_EXTENSION = ".key";
-const fs::path TPM_KEY_EXTENSION = ".tkey";
-const fs::path CERT_HASH_EXTENSION = ".hash";
-
 namespace conversions {
 std::string encoding_format_to_string(EncodingFormat e);
 std::string ca_certificate_type_to_string(CaCertificateType e);
@@ -156,7 +155,7 @@ std::string leaf_certificate_type_to_string(LeafCertificateType e);
 std::string leaf_certificate_type_to_filename(LeafCertificateType e);
 std::string certificate_type_to_string(CertificateType e);
 std::string hash_algorithm_to_string(HashAlgorithm e);
-HashAlgorithm string_to_hash_algorithm(std::string s);
+HashAlgorithm string_to_hash_algorithm(const std::string& s);
 std::string install_certificate_result_to_string(InstallCertificateResult e);
 std::string delete_certificate_result_to_string(DeleteCertificateResult e);
 std::string get_installed_certificates_status_to_string(GetInstalledCertificatesStatus e);

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -144,6 +144,12 @@ struct GetCertificateInfoResult {
     std::optional<CertificateInfo> info;
 };
 
+const fs::path PEM_EXTENSION = ".pem";
+const fs::path DER_EXTENSION = ".der";
+const fs::path KEY_EXTENSION = ".key";
+const fs::path TPM_KEY_EXTENSION = ".tkey";
+const fs::path CERT_HASH_EXTENSION = ".hash";
+
 namespace conversions {
 std::string encoding_format_to_string(EncodingFormat e);
 std::string ca_certificate_type_to_string(CaCertificateType e);

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -126,7 +126,7 @@ struct OCSPRequestDataList {
 
 struct CertificateOCSP {
     CertificateHashData hash;
-    std::optional<fs::path> oscsp_data;
+    std::optional<std::string> oscsp_data;
 };
 
 struct CertificateInfo {
@@ -135,7 +135,7 @@ struct CertificateInfo {
     std::optional<fs::path> certificate_single; ///< The path of the PEM or DER encoded certificate if found
     int certificate_count;               ///< The count of certificates, if the chain is available, or 1 if single
     std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
-    std::vector<CertificateOCSP> oscsp;  ///< The ordered list of OCSP certificate data based on the chain file order
+    std::vector<CertificateOCSP> ocsp;   ///< The ordered list of OCSP certificate data based on the chain file order
 };
 
 struct GetCertificateInfoResult {
@@ -156,6 +156,7 @@ std::string leaf_certificate_type_to_string(LeafCertificateType e);
 std::string leaf_certificate_type_to_filename(LeafCertificateType e);
 std::string certificate_type_to_string(CertificateType e);
 std::string hash_algorithm_to_string(HashAlgorithm e);
+HashAlgorithm string_to_hash_algorithm(std::string s);
 std::string install_certificate_result_to_string(InstallCertificateResult e);
 std::string delete_certificate_result_to_string(DeleteCertificateResult e);
 std::string get_installed_certificates_status_to_string(GetInstalledCertificatesStatus e);

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -133,10 +133,9 @@ struct CertificateInfo {
     fs::path key;                               ///< The path of the PEM or DER encoded private key
     std::optional<fs::path> certificate;        ///< The path of the PEM or DER encoded certificate chain if found
     std::optional<fs::path> certificate_single; ///< The path of the PEM or DER encoded certificate if found
-    int certificate_count; ///< The count of certificates in the chain, if the chain is available, or if single 1
+    int certificate_count;               ///< The count of certificates, if the chain is available, or 1 if single
     std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
-    std::vector<CertificateOCSP>
-        oscsp; ///< Contains the ordered list of OCSP certificate data based on the chain file order
+    std::vector<CertificateOCSP> oscsp;  ///< The ordered list of OCSP certificate data based on the chain file order
 };
 
 struct GetCertificateInfoResult {

--- a/include/evse_security/utils/evse_filesystem.hpp
+++ b/include/evse_security/utils/evse_filesystem.hpp
@@ -14,6 +14,8 @@ bool is_subdirectory(const fs::path& base, const fs::path& subdir);
 
 /// @brief Should be used to ensure file exists, not for directories
 bool create_file_if_nonexistent(const fs::path& file_path);
+/// @brief Ensure a file exists (if there's an extension), or a directory if no extension is found
+bool create_file_or_dir_if_nonexistent(const fs::path& file_path);
 bool delete_file(const fs::path& file_path);
 
 bool read_from_file(const fs::path& file_path, std::string& out_data);

--- a/include/evse_security/utils/evse_filesystem.hpp
+++ b/include/evse_security/utils/evse_filesystem.hpp
@@ -6,6 +6,8 @@
 
 #include <evse_security/utils/evse_filesystem_types.hpp>
 
+struct CertificateHashData;
+
 namespace evse_security::filesystem_utils {
 
 bool is_subdirectory(const fs::path& base, const fs::path& subdir);
@@ -24,5 +26,9 @@ bool process_file(const fs::path& file_path, size_t buffer_size,
                   std::function<bool(const std::uint8_t*, std::size_t, bool last_chunk)>&& func);
 
 std::string get_random_file_name(const std::string& extension);
+
+/// @brief Attempts to read a certificate hash from a file. The extension is taken into account
+/// @return True if we could read, false otherwise
+bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_hash);
 
 } // namespace evse_security::filesystem_utils

--- a/include/evse_security/utils/evse_filesystem.hpp
+++ b/include/evse_security/utils/evse_filesystem.hpp
@@ -31,4 +31,8 @@ std::string get_random_file_name(const std::string& extension);
 /// @return True if we could read, false otherwise
 bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_hash);
 
+/// @brief Attempts to write a certificate hash to a file
+/// @return True if we could write, false otherwise
+bool write_hash_to_file(const fs::path& file_path, const CertificateHashData& hash);
+
 } // namespace evse_security::filesystem_utils

--- a/include/evse_security/utils/evse_filesystem.hpp
+++ b/include/evse_security/utils/evse_filesystem.hpp
@@ -21,7 +21,7 @@ bool write_to_file(const fs::path& file_path, const std::string& data, std::ios:
 /// returns false, this function will also immediately  return
 /// @return True if the file was properly opened false otherwise
 bool process_file(const fs::path& file_path, size_t buffer_size,
-                  std::function<bool(const std::byte*, std::size_t, bool last_chunk)>&& func);
+                  std::function<bool(const std::uint8_t*, std::size_t, bool last_chunk)>&& func);
 
 std::string get_random_file_name(const std::string& extension);
 

--- a/lib/evse_security/CMakeLists.txt
+++ b/lib/evse_security/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(evse_security
         utils/evse_filesystem.cpp
 
         crypto/interface/crypto_supplier.cpp
+        crypto/interface/crypto_types.cpp
         crypto/openssl/openssl_supplier.cpp
         crypto/openssl/openssl_tpm.cpp
 )

--- a/lib/evse_security/certificate/x509_bundle.cpp
+++ b/lib/evse_security/certificate/x509_bundle.cpp
@@ -3,6 +3,7 @@
 #include <evse_security/certificate/x509_bundle.hpp>
 
 #include <algorithm>
+#include <fstream>
 
 #include <everest/logging.hpp>
 #include <evse_security/crypto/evse_crypto.hpp>
@@ -43,6 +44,20 @@ X509CertificateBundle::X509CertificateBundle(const std::string& certificate, con
 X509CertificateBundle::X509CertificateBundle(const fs::path& path, const EncodingFormat encoding) :
     hierarchy_invalidated(true) {
     this->path = path;
+
+    // In case the path is missing, create it
+    if (fs::exists(path) == false) {
+        if (path.has_extension()) {
+            if (path.extension() == PEM_EXTENSION) {
+                // Create file if we have an PEM extension
+                std::ofstream new_file(path.c_str());
+                new_file.close();
+            }
+        } else {
+            // Else create a directory
+            fs::create_directories(path);
+        }
+    }
 
     if (fs::is_directory(path)) {
         source = X509CertificateSource::DIRECTORY;

--- a/lib/evse_security/certificate/x509_bundle.cpp
+++ b/lib/evse_security/certificate/x509_bundle.cpp
@@ -45,19 +45,8 @@ X509CertificateBundle::X509CertificateBundle(const fs::path& path, const Encodin
     hierarchy_invalidated(true) {
     this->path = path;
 
-    // In case the path is missing, create it
-    if (fs::exists(path) == false) {
-        if (path.has_extension()) {
-            if (path.extension() == PEM_EXTENSION) {
-                // Create file if we have an PEM extension
-                std::ofstream new_file(path.c_str());
-                new_file.close();
-            }
-        } else {
-            // Else create a directory
-            fs::create_directories(path);
-        }
-    }
+    // Attempt creation
+    filesystem_utils::create_file_or_dir_if_nonexistent(path);
 
     if (fs::is_directory(path)) {
         source = X509CertificateSource::DIRECTORY;

--- a/lib/evse_security/certificate/x509_hierarchy.cpp
+++ b/lib/evse_security/certificate/x509_hierarchy.cpp
@@ -97,6 +97,20 @@ X509Wrapper X509CertificateHierarchy::find_certificate(const CertificateHashData
     throw NoCertificateFound("Could not find a certificate for hash: " + hash.issuer_name_hash);
 }
 
+std::vector<X509Wrapper> X509CertificateHierarchy::find_certificates_multi(const CertificateHashData& hash) {
+    std::vector<X509Wrapper> certificates;
+
+    for_each([&](X509Node& node) {
+        if (node.hash == hash) {
+            certificates.push_back(node.certificate);
+        }
+
+        return true;
+    });
+
+    return certificates;
+}
+
 std::string X509CertificateHierarchy::to_debug_string() {
     std::stringstream str;
 

--- a/lib/evse_security/certificate/x509_wrapper.cpp
+++ b/lib/evse_security/certificate/x509_wrapper.cpp
@@ -77,7 +77,9 @@ bool X509Wrapper::operator==(const X509Wrapper& other) const {
 }
 
 void X509Wrapper::update_validity() {
-    CryptoSupplier::x509_get_validity(get(), valid_in, valid_to);
+    if (false == CryptoSupplier::x509_get_validity(get(), valid_in, valid_to)) {
+        EVLOG_error << "Could not update validity for certificate: " << get_common_name();
+    }
 }
 
 bool X509Wrapper::is_child(const X509Wrapper& parent) const {

--- a/lib/evse_security/crypto/interface/crypto_supplier.cpp
+++ b/lib/evse_security/crypto/interface/crypto_supplier.cpp
@@ -86,8 +86,8 @@ KeyValidationResult AbstractCryptoSupplier::x509_check_private_key(X509Handle* h
     default_crypto_supplier_usage_error() return KeyValidationResult::Unknown;
 }
 
-bool AbstractCryptoSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
-                                                   const std::vector<std::byte>& data) {
+bool AbstractCryptoSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
+                                                   const std::vector<std::uint8_t>& data) {
     default_crypto_supplier_usage_error() return false;
 }
 
@@ -95,12 +95,25 @@ bool AbstractCryptoSupplier::x509_generate_csr(const CertificateSigningRequestIn
     default_crypto_supplier_usage_error() return false;
 }
 
-bool AbstractCryptoSupplier::digest_file_sha256(const fs::path& path, std::vector<std::byte>& out_digest) {
+bool AbstractCryptoSupplier::digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest) {
     default_crypto_supplier_usage_error() return false;
 }
 
-bool AbstractCryptoSupplier::decode_base64_signature(const std::string& signature,
-                                                     std::vector<std::byte>& out_decoded) {
+bool AbstractCryptoSupplier::base64_decode_to_bytes(const std::string& base64_string,
+                                                    std::vector<std::uint8_t>& out_decoded) {
+    default_crypto_supplier_usage_error() return false;
+}
+
+bool AbstractCryptoSupplier::base64_decode_to_string(const std::string& base64_string, std::string& out_decoded) {
+    default_crypto_supplier_usage_error() return false;
+}
+
+bool AbstractCryptoSupplier::base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes,
+                                                      std::string& out_encoded) {
+    default_crypto_supplier_usage_error() return false;
+}
+
+bool AbstractCryptoSupplier::base64_encode_from_string(const std::string& string, std::string& out_encoded) {
     default_crypto_supplier_usage_error() return false;
 }
 

--- a/lib/evse_security/crypto/interface/crypto_supplier.cpp
+++ b/lib/evse_security/crypto/interface/crypto_supplier.cpp
@@ -54,9 +54,9 @@ std::string AbstractCryptoSupplier::x509_get_common_name(X509Handle* handle) {
     default_crypto_supplier_usage_error() return {};
 }
 
-void AbstractCryptoSupplier::x509_get_validity(X509Handle* handle, std::int64_t& out_valid_in,
+bool AbstractCryptoSupplier::x509_get_validity(X509Handle* handle, std::int64_t& out_valid_in,
                                                std::int64_t& out_valid_to) {
-    default_crypto_supplier_usage_error()
+    default_crypto_supplier_usage_error() return false;
 }
 
 bool AbstractCryptoSupplier::x509_is_selfsigned(X509Handle* handle) {

--- a/lib/evse_security/crypto/interface/crypto_supplier.cpp
+++ b/lib/evse_security/crypto/interface/crypto_supplier.cpp
@@ -91,8 +91,9 @@ bool AbstractCryptoSupplier::x509_verify_signature(X509Handle* handle, const std
     default_crypto_supplier_usage_error() return false;
 }
 
-bool AbstractCryptoSupplier::x509_generate_csr(const CertificateSigningRequestInfo& csr_info, std::string& out_csr) {
-    default_crypto_supplier_usage_error() return false;
+CertificateSignRequestResult AbstractCryptoSupplier::x509_generate_csr(const CertificateSigningRequestInfo& csr_info,
+                                                                       std::string& out_csr) {
+    default_crypto_supplier_usage_error() return CertificateSignRequestResult::Unknown;
 }
 
 bool AbstractCryptoSupplier::digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest) {

--- a/lib/evse_security/crypto/interface/crypto_types.cpp
+++ b/lib/evse_security/crypto/interface/crypto_types.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Pionix GmbH and Contributors to EVerest
+
+#include <evse_security/crypto/interface/crypto_types.hpp>
+
+namespace evse_security {
+
+namespace conversions {
+
+std::string get_certificate_sign_request_result_to_string(CertificateSignRequestResult e) {
+
+    switch (e) {
+    case CertificateSignRequestResult::Valid:
+        return "Valid";
+    case CertificateSignRequestResult::KeyGenerationError:
+        return "KeyGenerationError";
+    case CertificateSignRequestResult::VersioningError:
+        return "VersioningError";
+    case CertificateSignRequestResult::PubkeyError:
+        return "PubkeyError";
+    case CertificateSignRequestResult::ExtensionsError:
+        return "ExtensionsError";
+    case CertificateSignRequestResult::SigningError:
+        return "SigningError";
+    }
+
+    throw std::out_of_range("No known string conversion for provided enum of type CertificateSignRequestResult");
+}
+
+} // namespace conversions
+
+} // namespace evse_security

--- a/lib/evse_security/crypto/openssl/openssl_supplier.cpp
+++ b/lib/evse_security/crypto/openssl/openssl_supplier.cpp
@@ -670,8 +670,8 @@ KeyValidationResult OpenSSLSupplier::x509_check_private_key(X509Handle* handle, 
     }
 }
 
-bool OpenSSLSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,
-                                            const std::vector<std::byte>& data) {
+bool OpenSSLSupplier::x509_verify_signature(X509Handle* handle, const std::vector<std::uint8_t>& signature,
+                                            const std::vector<std::uint8_t>& data) {
     OpenSSLProvider provider;
     provider.set_global_mode(OpenSSLProvider::mode_t::default_provider);
     // extract public key
@@ -819,7 +819,7 @@ bool OpenSSLSupplier::x509_generate_csr(const CertificateSigningRequestInfo& csr
     return true;
 }
 
-bool OpenSSLSupplier::digest_file_sha256(const fs::path& path, std::vector<std::byte>& out_digest) {
+bool OpenSSLSupplier::digest_file_sha256(const fs::path& path, std::vector<std::uint8_t>& out_digest) {
     EVP_MD_CTX_ptr md_context_ptr(EVP_MD_CTX_create());
     if (!md_context_ptr.get()) {
         EVLOG_error << "Could not create EVP_MD_CTX";
@@ -835,11 +835,11 @@ bool OpenSSLSupplier::digest_file_sha256(const fs::path& path, std::vector<std::
     bool digest_error = false;
 
     unsigned int sha256_out_length = 0;
-    std::byte sha256_out[EVP_MAX_MD_SIZE];
+    std::uint8_t sha256_out[EVP_MAX_MD_SIZE];
 
     // calculate sha256 of file
     bool processed_file = filesystem_utils::process_file(
-        path, BUFSIZ, [&](const std::byte* bytes, std::size_t read, bool last_chunk) -> bool {
+        path, BUFSIZ, [&](const std::uint8_t* bytes, std::size_t read, bool last_chunk) -> bool {
             if (read > 0) {
                 if (EVP_DigestUpdate(md_context_ptr.get(), bytes, read) == 0) {
                     EVLOG_error << "Error during EVP_DigestUpdate";
@@ -871,8 +871,7 @@ bool OpenSSLSupplier::digest_file_sha256(const fs::path& path, std::vector<std::
     return true;
 }
 
-bool OpenSSLSupplier::decode_base64_signature(const std::string& signature, std::vector<std::byte>& out_decoded) {
-    // decode base64 encoded signature
+template <typename T> static bool base64_decode(const std::string& base64_string, T& out_decoded) {
     EVP_ENCODE_CTX_ptr base64_decode_context_ptr(EVP_ENCODE_CTX_new());
     if (!base64_decode_context_ptr.get()) {
         EVLOG_error << "Error during EVP_ENCODE_CTX_new";
@@ -885,28 +884,77 @@ bool OpenSSLSupplier::decode_base64_signature(const std::string& signature, std:
         return false;
     }
 
-    const unsigned char* signature_str = reinterpret_cast<const unsigned char*>(signature.data());
-    int base64_length = signature.size();
-    std::byte signature_out[base64_length];
+    const unsigned char* encoded_str = reinterpret_cast<const unsigned char*>(base64_string.data());
+    int base64_length = base64_string.size();
 
-    int signature_out_length;
-    if (EVP_DecodeUpdate(base64_decode_context_ptr.get(), reinterpret_cast<unsigned char*>(signature_out),
-                         &signature_out_length, signature_str, base64_length) < 0) {
+    std::uint8_t decoded_out[base64_length];
+
+    int decoded_out_length;
+    if (EVP_DecodeUpdate(base64_decode_context_ptr.get(), reinterpret_cast<unsigned char*>(decoded_out),
+                         &decoded_out_length, encoded_str, base64_length) < 0) {
         EVLOG_error << "Error during DecodeUpdate";
         return false;
     }
 
     int decode_final_out;
-    if (EVP_DecodeFinal(base64_decode_context_ptr.get(), reinterpret_cast<unsigned char*>(signature_out),
+    if (EVP_DecodeFinal(base64_decode_context_ptr.get(), reinterpret_cast<unsigned char*>(decoded_out),
                         &decode_final_out) < 0) {
         EVLOG_error << "Error during EVP_DecodeFinal";
         return false;
     }
 
     out_decoded.clear();
-    out_decoded.insert(std::end(out_decoded), signature_out, signature_out + signature_out_length);
+    out_decoded.insert(std::end(out_decoded), decoded_out, decoded_out + decoded_out_length);
 
     return true;
+}
+
+static bool base64_encode(const unsigned char* bytes_str, int bytes_size, std::string& out_encoded) {
+    EVP_ENCODE_CTX_ptr base64_encode_context_ptr(EVP_ENCODE_CTX_new());
+    if (!base64_encode_context_ptr.get()) {
+        EVLOG_error << "Error during EVP_ENCODE_CTX_new";
+        return false;
+    }
+
+    EVP_EncodeInit(base64_encode_context_ptr.get());
+    if (!base64_encode_context_ptr.get()) {
+        EVLOG_error << "Error during EVP_EncodeInit";
+        return false;
+    }
+
+    int base64_length = ((bytes_size * 4) / 3) + 1;
+    char base64_out[base64_length]; // If it causes issues, replace with 'alloca' on different platform
+
+    int base64_out_length;
+    if (EVP_EncodeUpdate(base64_encode_context_ptr.get(), reinterpret_cast<unsigned char*>(base64_out),
+                         &base64_out_length, bytes_str, base64_length) < 0) {
+        EVLOG_error << "Error during EVP_EncodeUpdate";
+        return false;
+    }
+
+    int encode_final_out;
+    EVP_EncodeFinal(base64_encode_context_ptr.get(), reinterpret_cast<unsigned char*>(base64_out), &encode_final_out);
+
+    out_encoded.clear();
+    out_encoded.insert(std::end(out_encoded), base64_out, base64_out + base64_out_length);
+
+    return true;
+}
+
+bool OpenSSLSupplier::base64_decode_to_bytes(const std::string& base64_string, std::vector<std::uint8_t>& out_decoded) {
+    return base64_decode<std::vector<std::uint8_t>>(base64_string, out_decoded);
+}
+
+bool OpenSSLSupplier::base64_decode_to_string(const std::string& base64_string, std::string& out_decoded) {
+    return base64_decode<std::string>(base64_string, out_decoded);
+}
+
+bool OpenSSLSupplier::base64_encode_from_bytes(const std::vector<std::uint8_t>& bytes, std::string& out_encoded) {
+    return base64_encode(reinterpret_cast<const unsigned char*>(bytes.data()), bytes.size(), out_encoded);
+}
+
+bool OpenSSLSupplier::base64_encode_from_string(const std::string& string, std::string& out_encoded) {
+    return base64_encode(reinterpret_cast<const unsigned char*>(string.data()), string.size(), out_encoded);
 }
 
 } // namespace evse_security

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -865,14 +865,13 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
     }
 }
 
-std::optional<std::string> EvseSecurity::retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data) {
+std::optional<fs::path> EvseSecurity::retrieve_ocsp_cache(const CertificateHashData& certificate_hash_data) {
     std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
 
     return retrieve_ocsp_cache_internal(certificate_hash_data);
 }
 
-std::optional<std::string>
-EvseSecurity::retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data) {
+std::optional<fs::path> EvseSecurity::retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data) {
     // TODO(ioan): shouldn't we also do this for the MO?
     const auto ca_bundle_path = this->ca_bundle_path_map.at(CaCertificateType::V2G);
     const auto leaf_path = this->directories.secc_leaf_key_directory;
@@ -903,13 +902,8 @@ EvseSecurity::retrieve_ocsp_cache_internal(const CertificateHashData& certificat
                             fs::path replaced_ext = ocsp_entry.path();
                             replaced_ext.replace_extension(DER_EXTENSION);
 
-                            std::ifstream in_fs(replaced_ext.c_str());
-                            std::string ocsp_response;
-
-                            in_fs >> ocsp_response;
-                            in_fs.close();
-
-                            return std::make_optional<std::string>(std::move(ocsp_response));
+                            // Return the data file's path
+                            return std::make_optional<fs::path>(replaced_ext);
                         }
                     }
                 }
@@ -1182,7 +1176,7 @@ GetCertificateInfoResult EvseSecurity::get_leaf_certificate_info_internal(LeafCe
                 for (const auto& chain_certif : *leaf_fullchain) {
                     try {
                         CertificateHashData hash = hierarchy.get_certificate_hash(chain_certif);
-                        std::optional<std::string> data = retrieve_ocsp_cache_internal(hash);
+                        std::optional<fs::path> data = retrieve_ocsp_cache_internal(hash);
 
                         certificate_ocsp.push_back({hash, data});
                     } catch (const NoCertificateFound& e) {
@@ -1326,8 +1320,10 @@ std::string EvseSecurity::get_verify_file(CaCertificateType certificate_type) {
                     << this->ca_bundle_path_map.at(certificate_type) << " with error: " << e.what();
     }
 
-    throw NoCertificateFound("Could not find any CA certificate for: " +
-                             conversions::ca_certificate_type_to_string(certificate_type));
+    EVLOG_error << "Could not find any CA certificate for: "
+                << conversions::ca_certificate_type_to_string(certificate_type);
+
+    return {};
 }
 
 int EvseSecurity::get_leaf_expiry_days_count(LeafCertificateType certificate_type) {
@@ -1563,107 +1559,112 @@ void EvseSecurity::garbage_collect() {
     // Order by latest valid, and keep newest with a safety limit
     for (auto const& [cert_dir, key_dir, ca_type] : leaf_paths) {
         // Root bundle required for hash of OCSP cache
-        X509CertificateBundle root_bundle(ca_bundle_path_map[ca_type], EncodingFormat::PEM);
-        X509CertificateBundle expired_certs(cert_dir, EncodingFormat::PEM);
+        try {
+            X509CertificateBundle root_bundle(ca_bundle_path_map[ca_type], EncodingFormat::PEM);
+            X509CertificateBundle expired_certs(cert_dir, EncodingFormat::PEM);
 
-        // Only handle if we have more than the minimum certificates entry
-        if (expired_certs.get_certificate_chains_count() > DEFAULT_MINIMUM_CERTIFICATE_ENTRIES) {
-            fs::path key_directory = key_dir;
-            int skipped = 0;
+            // Only handle if we have more than the minimum certificates entry
+            if (expired_certs.get_certificate_chains_count() > DEFAULT_MINIMUM_CERTIFICATE_ENTRIES) {
+                fs::path key_directory = key_dir;
+                int skipped = 0;
 
-            // Order by expiry date, and keep even expired certificates with a minimum of 10 certificates
-            expired_certs.for_each_chain_ordered(
-                [this, &invalid_certificate_files, &skipped, &key_directory, &protected_private_keys,
-                 &root_bundle](const fs::path& file, const std::vector<X509Wrapper>& chain) {
-                    // By default delete all empty
-                    if (chain.size() <= 0) {
-                        invalid_certificate_files.emplace(file);
-                    }
-
-                    if (++skipped > DEFAULT_MINIMUM_CERTIFICATE_ENTRIES) {
-                        if (chain.empty()) {
-                            return true;
+                // Order by expiry date, and keep even expired certificates with a minimum of 10 certificates
+                expired_certs.for_each_chain_ordered(
+                    [this, &invalid_certificate_files, &skipped, &key_directory, &protected_private_keys,
+                     &root_bundle](const fs::path& file, const std::vector<X509Wrapper>& chain) {
+                        // By default delete all empty
+                        if (chain.size() <= 0) {
+                            invalid_certificate_files.emplace(file);
                         }
 
-                        // If the chain contains the first expired (leafs are the first)
-                        if (chain[0].is_expired()) {
-                            invalid_certificate_files.emplace(file);
-
-                            // Also attempt to add the key for deletion
-                            try {
-                                fs::path key_file = get_private_key_path_of_certificate(chain[0], key_directory,
-                                                                                        this->private_key_password);
-                                invalid_certificate_files.emplace(key_file);
-                            } catch (NoPrivateKeyException& e) {
+                        if (++skipped > DEFAULT_MINIMUM_CERTIFICATE_ENTRIES) {
+                            if (chain.empty()) {
+                                return true;
                             }
 
-                            auto leaf_chain = chain;
-                            X509CertificateHierarchy hierarchy =
-                                std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_chain));
+                            // If the chain contains the first expired (leafs are the first)
+                            if (chain[0].is_expired()) {
+                                invalid_certificate_files.emplace(file);
 
-                            try {
-                                CertificateHashData ocsp_hash = hierarchy.get_certificate_hash(chain[0]);
+                                // Also attempt to add the key for deletion
+                                try {
+                                    fs::path key_file = get_private_key_path_of_certificate(chain[0], key_directory,
+                                                                                            this->private_key_password);
+                                    invalid_certificate_files.emplace(key_file);
+                                } catch (NoPrivateKeyException& e) {
+                                }
 
-                                // Find OCSP cache with hash
-                                if (chain[0].get_file().has_value()) {
-                                    const auto ocsp_path = chain[0].get_file().value().parent_path() / "ocsp";
+                                auto leaf_chain = chain;
+                                X509CertificateHierarchy hierarchy = std::move(
+                                    X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_chain));
 
-                                    if (fs::exists(ocsp_path)) {
-                                        for (const auto& hash_entry : fs::directory_iterator(ocsp_path)) {
-                                            if (hash_entry.is_regular_file() == false) {
-                                                continue;
-                                            }
-                                            // Attempt hash read
-                                            CertificateHashData read_hash;
+                                try {
+                                    CertificateHashData ocsp_hash = hierarchy.get_certificate_hash(chain[0]);
 
-                                            if (filesystem_utils::read_hash_from_file(hash_entry.path(), read_hash) &&
-                                                read_hash == ocsp_hash) {
+                                    // Find OCSP cache with hash
+                                    if (chain[0].get_file().has_value()) {
+                                        const auto ocsp_path = chain[0].get_file().value().parent_path() / "ocsp";
 
-                                                auto oscp_data_path = hash_entry.path();
-                                                oscp_data_path.replace_extension(CERT_HASH_EXTENSION);
+                                        if (fs::exists(ocsp_path)) {
+                                            for (const auto& hash_entry : fs::directory_iterator(ocsp_path)) {
+                                                if (hash_entry.is_regular_file() == false) {
+                                                    continue;
+                                                }
+                                                // Attempt hash read
+                                                CertificateHashData read_hash;
 
-                                                invalid_certificate_files.emplace(hash_entry.path());
-                                                invalid_certificate_files.emplace(oscp_data_path);
+                                                if (filesystem_utils::read_hash_from_file(hash_entry.path(),
+                                                                                          read_hash) &&
+                                                    read_hash == ocsp_hash) {
+
+                                                    auto oscp_data_path = hash_entry.path();
+                                                    oscp_data_path.replace_extension(DER_EXTENSION);
+
+                                                    invalid_certificate_files.emplace(hash_entry.path());
+                                                    invalid_certificate_files.emplace(oscp_data_path);
+                                                }
                                             }
                                         }
                                     }
+                                } catch (const NoCertificateFound& e) {
                                 }
-                            } catch (const NoCertificateFound& e) {
+                            }
+                        } else {
+                            // Add to protected certificate list
+                            try {
+                                fs::path key_file = get_private_key_path_of_certificate(chain[0], key_directory,
+                                                                                        this->private_key_password);
+                                protected_private_keys.emplace(key_file);
+
+                                // Erase all protected keys from the managed CRSs
+                                auto it = managed_csr.find(key_file);
+                                if (it != managed_csr.end()) {
+                                    managed_csr.erase(it);
+                                }
+                            } catch (NoPrivateKeyException& e) {
                             }
                         }
-                    } else {
-                        // Add to protected certificate list
-                        try {
-                            fs::path key_file = get_private_key_path_of_certificate(chain[0], key_directory,
-                                                                                    this->private_key_password);
-                            protected_private_keys.emplace(key_file);
 
-                            // Erase all protected keys from the managed CRSs
-                            auto it = managed_csr.find(key_file);
-                            if (it != managed_csr.end()) {
-                                managed_csr.erase(it);
-                            }
-                        } catch (NoPrivateKeyException& e) {
+                        return true;
+                    },
+                    [](const std::vector<X509Wrapper>& a, const std::vector<X509Wrapper>& b) {
+                        // Order from newest to oldest (newest DEFAULT_MINIMUM_CERTIFICATE_ENTRIES) are kept
+                        // even if they are expired
+                        if (a.size() && b.size()) {
+                            return a.at(0).get_valid_to() > b.at(0).get_valid_to();
+                        } else {
+                            return false;
                         }
-                    }
-
-                    return true;
-                },
-                [](const std::vector<X509Wrapper>& a, const std::vector<X509Wrapper>& b) {
-                    // Order from newest to oldest (newest DEFAULT_MINIMUM_CERTIFICATE_ENTRIES) are kept
-                    // even if they are expired
-                    if (a.size() && b.size()) {
-                        return a.at(0).get_valid_to() > b.at(0).get_valid_to();
-                    } else {
-                        return false;
-                    }
-                });
+                    });
+            }
+        } catch (const CertificateLoadException& e) {
+            EVLOG_warning << "Could not load bundle from file: " << e.what();
         }
-    }
+    } // End leaf for iteration
 
     for (const auto& expired_certificate_file : invalid_certificate_files) {
         if (filesystem_utils::delete_file(expired_certificate_file))
-            EVLOG_debug << "Deleted expired certificate file: " << expired_certificate_file;
+            EVLOG_info << "Deleted expired certificate file: " << expired_certificate_file;
         else
             EVLOG_warning << "Error deleting expired certificate file: " << expired_certificate_file;
     }
@@ -1718,6 +1719,81 @@ void EvseSecurity::garbage_collect() {
         } else {
             ++it;
         }
+    }
+
+    std::set<fs::path> invalid_ocsp_files;
+
+    // Delete all non-owned OCSP data
+    for (const auto& leaf_certificate_path :
+         {directories.secc_leaf_cert_directory, directories.csms_leaf_cert_directory}) {
+        try {
+            bool secc = (leaf_certificate_path == directories.secc_leaf_cert_directory);
+            bool csms = (leaf_certificate_path == directories.csms_leaf_cert_directory) ||
+                        (directories.csms_leaf_cert_directory == directories.secc_leaf_cert_directory);
+
+            CaCertificateType load;
+
+            if (secc)
+                load = CaCertificateType::V2G;
+            else if (csms)
+                load = CaCertificateType::CSMS;
+
+            // Also load the roots since we need to build the hierarchy for correct certificate hashes
+            X509CertificateBundle root_bundle(ca_bundle_path_map[load], EncodingFormat::PEM);
+            X509CertificateBundle leaf_bundle(leaf_certificate_path, EncodingFormat::PEM);
+
+            fs::path leaf_ocsp;
+            fs::path root_ocsp;
+
+            if (root_bundle.is_using_bundle_file()) {
+                root_ocsp = root_bundle.get_path().parent_path() / "ocsp";
+            } else {
+                root_ocsp = root_bundle.get_path() / "ocsp";
+            }
+
+            if (leaf_bundle.is_using_bundle_file()) {
+                leaf_ocsp = leaf_bundle.get_path().parent_path() / "ocsp";
+            } else {
+                leaf_ocsp = leaf_bundle.get_path() / "ocsp";
+            }
+
+            X509CertificateHierarchy hierarchy =
+                std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_bundle.split()));
+
+            // Iterate all hashes folders and see if any are missing
+            for (auto& ocsp_dir : {leaf_ocsp, root_ocsp}) {
+                if (fs::exists(ocsp_dir)) {
+                    for (auto& ocsp_entry : fs::directory_iterator(ocsp_dir)) {
+                        if (ocsp_entry.is_regular_file() == false) {
+                            continue;
+                        }
+
+                        // Attempt hash read
+                        CertificateHashData read_hash;
+
+                        if (filesystem_utils::read_hash_from_file(ocsp_entry.path(), read_hash)) {
+                            // If we can't find the has, it means it was deleted somehow, add to delete list
+                            if (hierarchy.contains_certificate_hash(read_hash) == false) {
+                                auto oscp_data_path = ocsp_entry.path();
+                                oscp_data_path.replace_extension(DER_EXTENSION);
+
+                                invalid_ocsp_files.emplace(ocsp_entry.path());
+                                invalid_ocsp_files.emplace(oscp_data_path);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (const CertificateLoadException& e) {
+            EVLOG_warning << "Could not load ca bundle from file: " << leaf_certificate_path;
+        }
+    }
+
+    for (const auto& invalid_ocsp : invalid_ocsp_files) {
+        if (filesystem_utils::delete_file(invalid_ocsp))
+            EVLOG_info << "Deleted invalid ocsp file: " << invalid_ocsp;
+        else
+            EVLOG_warning << "Error deleting invalid ocsp file: " << invalid_ocsp;
     }
 }
 

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -1414,10 +1414,11 @@ int EvseSecurity::get_leaf_expiry_days_count(LeafCertificateType certificate_typ
             fs::path certificate_path;
 
             if (key_pair.info.has_value()) {
-                if (key_pair.info.value().certificate.has_value())
+                if (key_pair.info.value().certificate.has_value()) {
                     certificate_path = key_pair.info.value().certificate.value();
-                else
+                } else {
                     certificate_path = key_pair.info.value().certificate_single.value();
+                }
             }
 
             if (certificate_path.empty() == false) {

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -1353,18 +1353,20 @@ GetCertificateInfoResult EvseSecurity::get_ca_certificate_info_internal(CaCertif
             for (auto& root : hierarchy.get_hierarchy()) {
                 if (root.certificate.is_selfsigned() && root.certificate.is_valid()) {
                     CertificateInfo info;
-                    result.info = info;
+                    info.certificate = root.certificate.get_file().value();
+                    info.certificate_single = root.certificate.get_file().value();
 
-                    result.info.value().certificate = root.certificate.get_file().value();
+                    result.info = info;
                     result.status = GetCertificateInfoStatus::Accepted;
                     return result;
                 }
             }
         } else {
             CertificateInfo info;
-            result.info = info;
+            info.certificate = verify_file.get_path();
+            info.certificate_single = verify_file.get_path();
 
-            result.info.value().certificate = verify_file.get_path();
+            result.info = info;
             result.status = GetCertificateInfoStatus::Accepted;
             return result;
         }
@@ -1393,7 +1395,7 @@ std::string EvseSecurity::get_verify_file(CaCertificateType certificate_type) {
 
     if (result.status == GetCertificateInfoStatus::Accepted && result.info.has_value()) {
         if (result.info.value().certificate.has_value()) {
-            result.info.value().certificate.value().string();
+            return result.info.value().certificate.value().string();
         }
     }
 

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -638,7 +638,7 @@ EvseSecurity::get_installed_certificates(const std::vector<CertificateType>& cer
                         certificate_chains.push_back(certificate_hash_data_chain);
                     }
                 }
-            } catch(const CertificateLoadException& e) {
+            } catch (const CertificateLoadException& e) {
                 EVLOG_error << "Could not load installed leaf certificates: " << e.what();
             }
         }
@@ -671,7 +671,7 @@ int EvseSecurity::get_count_of_installed_certificates(const std::vector<Certific
         try {
             X509CertificateBundle ca_bundle(unique_dir, EncodingFormat::PEM);
             count += ca_bundle.get_certificate_count();
-        } catch(const CertificateLoadException& e) {
+        } catch (const CertificateLoadException& e) {
             EVLOG_error << "Could not load bundle for certificate count: " << e.what();
         }
     }
@@ -685,7 +685,7 @@ int EvseSecurity::get_count_of_installed_certificates(const std::vector<Certific
         try {
             X509CertificateBundle leaf_bundle(leaf_dir, EncodingFormat::PEM);
             count += leaf_bundle.get_certificate_count();
-        } catch(const CertificateLoadException& e) {
+        } catch (const CertificateLoadException& e) {
             EVLOG_error << "Could not load bundle for certificate count: " << e.what();
         }
     }

--- a/lib/evse_security/evse_types.cpp
+++ b/lib/evse_security/evse_types.cpp
@@ -93,6 +93,17 @@ std::string hash_algorithm_to_string(HashAlgorithm e) {
     }
 };
 
+HashAlgorithm string_to_hash_algorithm(std::string s) {
+    if (s == "SHA256")
+        return HashAlgorithm::SHA256;
+    else if (s == "SHA384")
+        return HashAlgorithm::SHA384;
+    else if (s == "SHA512")
+        return HashAlgorithm::SHA512;
+
+    throw std::out_of_range("Could not convert string to HashAlgorithm");
+}
+
 std::string install_certificate_result_to_string(InstallCertificateResult e) {
     switch (e) {
     case InstallCertificateResult::InvalidSignature:

--- a/lib/evse_security/evse_types.cpp
+++ b/lib/evse_security/evse_types.cpp
@@ -142,20 +142,20 @@ std::string get_installed_certificates_status_to_string(GetInstalledCertificates
     }
 };
 
-std::string get_key_pair_status_to_string(GetKeyPairStatus e) {
+std::string get_key_pair_status_to_string(GetCertificateInfoStatus e) {
     switch (e) {
-    case GetKeyPairStatus::Accepted:
+    case GetCertificateInfoStatus::Accepted:
         return "Accepted";
-    case GetKeyPairStatus::Rejected:
+    case GetCertificateInfoStatus::Rejected:
         return "Rejected";
-    case GetKeyPairStatus::NotFound:
+    case GetCertificateInfoStatus::NotFound:
         return "NotFound";
-    case GetKeyPairStatus::NotFoundValid:
+    case GetCertificateInfoStatus::NotFoundValid:
         return "NotFoundValid";
-    case GetKeyPairStatus::PrivateKeyNotFound:
+    case GetCertificateInfoStatus::PrivateKeyNotFound:
         return "PrivateKeyNotFound";
     default:
-        throw std::out_of_range("Could not convert GetKeyPairStatus to string");
+        throw std::out_of_range("Could not convert GetCertificateInfoStatus to string");
     }
 };
 

--- a/lib/evse_security/evse_types.cpp
+++ b/lib/evse_security/evse_types.cpp
@@ -93,7 +93,7 @@ std::string hash_algorithm_to_string(HashAlgorithm e) {
     }
 };
 
-HashAlgorithm string_to_hash_algorithm(std::string s) {
+HashAlgorithm string_to_hash_algorithm(const std::string& s) {
     if (s == "SHA256")
         return HashAlgorithm::SHA256;
     else if (s == "SHA384")

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2023 Pionix GmbH and Contributors to EVerest
+#include <evse_security/evse_types.hpp>
 #include <evse_security/utils/evse_filesystem.hpp>
 
 #include <fstream>
@@ -116,6 +117,27 @@ std::string get_random_file_name(const std::string& extension) {
          << distribution(generator) << extension;
 
     return buff.str();
+}
+
+bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_hash) {
+    if (file_path.extension() == CERT_HASH_EXTENSION) {
+        try {
+            std::ifstream hs(file_path);
+
+            hs >> out_hash.issuer_name_hash;
+            hs >> out_hash.issuer_key_hash;
+            hs >> out_hash.serial_number;
+
+            hs.close();
+
+            return true;
+        } catch (const std::exception& e) {
+            EVLOG_error << "Unknown error occurred while reading cert hash file: " << file_path;
+            return false;
+        }
+    }
+
+    return false;
 }
 
 } // namespace evse_security::filesystem_utils

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -140,4 +140,28 @@ bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_has
     return false;
 }
 
+bool write_hash_to_file(const fs::path& file_path, const CertificateHashData& hash) {
+    auto real_path = file_path;
+
+    if (file_path.has_extension() == false || file_path.extension() != CERT_HASH_EXTENSION) {
+        real_path.replace_extension(CERT_HASH_EXTENSION);
+    }
+
+    try {
+        // Write out the related hash
+        std::ofstream hs(real_path.c_str());
+        hs << hash.issuer_name_hash;
+        hs << hash.issuer_key_hash;
+        hs << hash.serial_number;
+        hs.close();
+
+        return true;
+    } catch (const std::exception& e) {
+        EVLOG_error << "Unknown error occurred writing cert hash file: " << file_path;
+        return false;
+    }
+
+    return false;
+}
+
 } // namespace evse_security::filesystem_utils

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -123,16 +123,19 @@ bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_has
     if (file_path.extension() == CERT_HASH_EXTENSION) {
         try {
             std::ifstream hs(file_path);
+            std::string algo;
 
+            hs >> algo;
             hs >> out_hash.issuer_name_hash;
             hs >> out_hash.issuer_key_hash;
             hs >> out_hash.serial_number;
-
             hs.close();
+
+            out_hash.hash_algorithm = conversions::string_to_hash_algorithm(algo);
 
             return true;
         } catch (const std::exception& e) {
-            EVLOG_error << "Unknown error occurred while reading cert hash file: " << file_path;
+            EVLOG_error << "Unknown error occurred while reading cert hash file: " << file_path << " err: " << e.what();
             return false;
         }
     }
@@ -150,14 +153,16 @@ bool write_hash_to_file(const fs::path& file_path, const CertificateHashData& ha
     try {
         // Write out the related hash
         std::ofstream hs(real_path.c_str());
-        hs << hash.issuer_name_hash;
-        hs << hash.issuer_key_hash;
-        hs << hash.serial_number;
+
+        hs << conversions::hash_algorithm_to_string(hash.hash_algorithm) << "\n";
+        hs << hash.issuer_name_hash << "\n";
+        hs << hash.issuer_key_hash << "\n";
+        hs << hash.serial_number << "\n";
         hs.close();
 
         return true;
     } catch (const std::exception& e) {
-        EVLOG_error << "Unknown error occurred writing cert hash file: " << file_path;
+        EVLOG_error << "Unknown error occurred writing cert hash file: " << file_path << " err: " << e.what();
         return false;
     }
 

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -73,7 +73,7 @@ bool write_to_file(const fs::path& file_path, const std::string& data, std::ios:
 }
 
 bool process_file(const fs::path& file_path, size_t buffer_size,
-                  std::function<bool(const std::byte*, std::size_t, bool last_chunk)>&& func) {
+                  std::function<bool(const std::uint8_t*, std::size_t, bool last_chunk)>&& func) {
     std::ifstream file(file_path, std::ios::binary);
 
     if (!file) {
@@ -81,7 +81,7 @@ bool process_file(const fs::path& file_path, size_t buffer_size,
         return false;
     }
 
-    std::vector<std::byte> buffer(buffer_size);
+    std::vector<std::uint8_t> buffer(buffer_size);
     bool interupted = false;
 
     while (file.read(reinterpret_cast<char*>(buffer.data()), buffer_size)) {

--- a/tests/openssl_supplier_test.cpp
+++ b/tests/openssl_supplier_test.cpp
@@ -41,15 +41,6 @@ TEST_F(OpenSSLSupplierTest, generate_key_RSA_3072) {
     ASSERT_TRUE(res);
 }
 
-TEST_F(OpenSSLSupplierTest, generate_key_RSA_7680) {
-    KeyGenerationInfo info = {
-        CryptoKeyType::RSA_7680, false, std::nullopt, std::nullopt, std::nullopt,
-    };
-    KeyHandle_ptr key;
-    auto res = OpenSSLSupplier::generate_key(info, key);
-    ASSERT_TRUE(res);
-}
-
 TEST_F(OpenSSLSupplierTest, generate_key_EC_prime256v1) {
     KeyGenerationInfo info = {
         CryptoKeyType::EC_prime256v1, false, std::nullopt, std::nullopt, std::nullopt,

--- a/tests/openssl_supplier_test.cpp
+++ b/tests/openssl_supplier_test.cpp
@@ -104,7 +104,7 @@ TEST_F(OpenSSLSupplierTest, x509_generate_csr) {
         .ip_address = std::nullopt,
         {CryptoKeyType::EC_prime256v1, false, std::nullopt, "pki/csr_key.pem", std::nullopt}};
     auto res = OpenSSLSupplier::x509_generate_csr(csr_info, csr);
-    ASSERT_TRUE(res);
+    ASSERT_EQ(res, CertificateSignRequestResult::Valid);
 
     std::ofstream out("csr.pem");
     out << csr;
@@ -124,7 +124,7 @@ TEST_F(OpenSSLSupplierTest, x509_generate_csr_dns) {
         .ip_address = std::nullopt,
         {CryptoKeyType::EC_prime256v1, false, std::nullopt, "pki/csr_key.pem", std::nullopt}};
     auto res = OpenSSLSupplier::x509_generate_csr(csr_info, csr);
-    ASSERT_TRUE(res);
+    ASSERT_EQ(res, CertificateSignRequestResult::Valid);
 
 #ifdef OUTPUT_CSR
     std::ofstream out("csr_dns.pem");
@@ -146,7 +146,7 @@ TEST_F(OpenSSLSupplierTest, x509_generate_csr_ip) {
         .ip_address = "127.0.0.1",
         {CryptoKeyType::EC_prime256v1, false, std::nullopt, "pki/csr_key.pem", std::nullopt}};
     auto res = OpenSSLSupplier::x509_generate_csr(csr_info, csr);
-    ASSERT_TRUE(res);
+    ASSERT_EQ(res, CertificateSignRequestResult::Valid);
 
 #ifdef OUTPUT_CSR
     std::ofstream out("csr_ip.pem");
@@ -168,7 +168,7 @@ TEST_F(OpenSSLSupplierTest, x509_generate_csr_dns_ip) {
         .ip_address = "127.0.0.1",
         {CryptoKeyType::EC_prime256v1, false, std::nullopt, "pki/csr_key.pem", std::nullopt}};
     auto res = OpenSSLSupplier::x509_generate_csr(csr_info, csr);
-    ASSERT_TRUE(res);
+    ASSERT_EQ(res, CertificateSignRequestResult::Valid);
 
 #ifdef OUTPUT_CSR
     std::ofstream out("csr_dns_ip.pem");

--- a/tests/openssl_supplier_test_tpm.cpp
+++ b/tests/openssl_supplier_test_tpm.cpp
@@ -41,16 +41,6 @@ TEST_F(OpenSSLSupplierTpmTest, generate_key_RSA_3072) {
     ASSERT_TRUE(res);
 }
 
-TEST_F(OpenSSLSupplierTpmTest, generate_key_RSA_7680) {
-    KeyGenerationInfo info = {
-        CryptoKeyType::RSA_7680, true, std::nullopt, std::nullopt, std::nullopt,
-    };
-    KeyHandle_ptr key;
-    auto res = OpenSSLSupplier::generate_key(info, key);
-    // not commonly supported by TPMs
-    ASSERT_FALSE(res);
-}
-
 TEST_F(OpenSSLSupplierTpmTest, generate_key_EC_prime256v1) {
     KeyGenerationInfo info = {
         CryptoKeyType::EC_prime256v1, true, std::nullopt, std::nullopt, std::nullopt,

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -915,6 +915,22 @@ TEST_F(EvseSecurityTests, verify_expired_csr_deletion) {
     ASSERT_FALSE(fs::exists(csr_key_path));
 }
 
+TEST_F(EvseSecurityTests, verify_base64) {
+    std::string test_string1 = "U29tZSBkYXRhIGZvciB0ZXN0IGNhc2VzLiBTb21lIGRhdGEgZm9yIHRlc3QgY2FzZXMuIFNvbWUgZGF0YSBmb3I"
+                               "gdGVzdCBjYXNlcy4gU29tZSBkYXRhIGZvciB0ZXN0IGNhc2VzLg==";
+
+    std::string decoded = this->evse_security->base64_decode_to_string(test_string1);
+    ASSERT_EQ(
+        decoded,
+        std::string(
+            "Some data for test cases. Some data for test cases. Some data for test cases. Some data for test cases."));
+
+    std::string out_encoded = this->evse_security->base64_encode_from_string(decoded);
+    out_encoded.erase(std::remove(out_encoded.begin(), out_encoded.end(), '\n'), out_encoded.cend());
+
+    ASSERT_EQ(test_string1, out_encoded);
+}
+
 } // namespace evse_security
 
 // FIXME(piet): Add more tests for getRootCertificateHashData (incl. V2GCertificateChain etc.)

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -833,6 +833,8 @@ TEST_F(EvseSecurityTestsExpired, verify_expired_leaf_deletion) {
     // Garbage collect
     evse_security->garbage_collect();
 
+    // TODO: (ioan) test OCSP cache deletion
+
     // Ensure that we have 10 certificates, since we only keep 10, the newest
     {
         X509CertificateBundle full_certs(fs::path("certs/client/cso"), EncodingFormat::PEM);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -732,7 +732,8 @@ TEST_F(EvseSecurityTests, get_installed_certificates_and_delete_secc_leaf) {
 }
 
 TEST_F(EvseSecurityTests, leaf_cert_starts_in_future_accepted) {
-    const auto v2g_keypair_before = this->evse_security->get_key_pair(LeafCertificateType::V2G, EncodingFormat::PEM);
+    const auto v2g_keypair_before =
+        this->evse_security->get_leaf_certificate_info(LeafCertificateType::V2G, EncodingFormat::PEM);
 
     const auto new_root_ca = read_file_to_string(std::filesystem::path("future_leaf/V2G_ROOT_CA.pem"));
     const auto result_ca = this->evse_security->install_ca_certificate(new_root_ca, CaCertificateType::V2G);
@@ -747,10 +748,11 @@ TEST_F(EvseSecurityTests, leaf_cert_starts_in_future_accepted) {
     ASSERT_TRUE(result_client == InstallCertificateResult::Accepted);
 
     // Check: The certificate is installed, but it isn't actually used
-    const auto v2g_keypair_after = this->evse_security->get_key_pair(LeafCertificateType::V2G, EncodingFormat::PEM);
-    ASSERT_EQ(v2g_keypair_after.pair.value().certificate, v2g_keypair_before.pair.value().certificate);
-    ASSERT_EQ(v2g_keypair_after.pair.value().key, v2g_keypair_before.pair.value().key);
-    ASSERT_EQ(v2g_keypair_after.pair.value().password, v2g_keypair_before.pair.value().password);
+    const auto v2g_keypair_after =
+        this->evse_security->get_leaf_certificate_info(LeafCertificateType::V2G, EncodingFormat::PEM);
+    ASSERT_EQ(v2g_keypair_after.info.value().certificate, v2g_keypair_before.info.value().certificate);
+    ASSERT_EQ(v2g_keypair_after.info.value().key, v2g_keypair_before.info.value().key);
+    ASSERT_EQ(v2g_keypair_after.info.value().password, v2g_keypair_before.info.value().password);
 }
 
 TEST_F(EvseSecurityTests, expired_leaf_cert_rejected) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -463,10 +463,27 @@ TEST_F(EvseSecurityTests, verify_v2g_cert_02) {
     ASSERT_TRUE(result != InstallCertificateResult::Accepted);
 }
 
+TEST_F(EvseSecurityTests, retrieve_root_ca) {
+    std::string path = "certs/ca/v2g/V2G_CA_BUNDLE.pem";
+    std::string retrieved_path = this->evse_security->get_verify_file(CaCertificateType::V2G);
+
+    ASSERT_EQ(path, retrieved_path);
+}
+
 TEST_F(EvseSecurityTests, install_root_ca_01) {
     const auto v2g_root_ca = read_file_to_string(fs::path("certs/ca/v2g/V2G_ROOT_CA_NEW.pem"));
     const auto result = this->evse_security->install_ca_certificate(v2g_root_ca, CaCertificateType::V2G);
     ASSERT_TRUE(result == InstallCertificateResult::Accepted);
+
+    std::string path = "certs/ca/v2g/V2G_CA_BUNDLE.pem";
+    ASSERT_EQ(this->evse_security->get_verify_file(CaCertificateType::V2G), path);
+
+    const auto read_v2g_root_ca = read_file_to_string(path);
+    X509CertificateBundle root_bundle(read_v2g_root_ca, EncodingFormat::PEM);
+    X509Wrapper new_root(v2g_root_ca, EncodingFormat::PEM);
+
+    // Assert it was really installed
+    ASSERT_TRUE(root_bundle.contains_certificate(new_root));
 }
 
 TEST_F(EvseSecurityTests, install_root_ca_02) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -21,7 +21,7 @@
 
 #if USING_OPENSSL_3
 // provider management has changed - ensure tests still work
-#ifndef USING_TPM2contains_certificate_hash
+#ifndef USING_TPM2
 
 #include <evse_security/detail/openssl/openssl_providers.hpp>
 #else

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -396,8 +396,8 @@ TEST_F(EvseSecurityTests, verify_tpm_keygen_csr) {
 
     std::string csr;
 
-    gen = CryptoSupplier::x509_generate_csr(csr_info, csr);
-    ASSERT_TRUE(gen);
+    auto csr_gen = CryptoSupplier::x509_generate_csr(csr_info, csr);
+    ASSERT_EQ(csr_gen, CertificateSignRequestResult::Valid);
 
     std::cout << "TPM csr: " << std::endl << csr << std::endl;
 
@@ -408,8 +408,8 @@ TEST_F(EvseSecurityTests, verify_tpm_keygen_csr) {
 
     csr_info.key_info = info;
 
-    gen = CryptoSupplier::x509_generate_csr(csr_info, csr);
-    ASSERT_TRUE(gen);
+    csr_gen = CryptoSupplier::x509_generate_csr(csr_info, csr);
+    ASSERT_EQ(csr_gen, CertificateSignRequestResult::Valid);
 
     std::cout << "normal csr: " << std::endl << csr << std::endl;
 }
@@ -1051,8 +1051,7 @@ TEST_F(EvseSecurityTestsExpired, verify_expired_leaf_deletion) {
 
 TEST_F(EvseSecurityTests, verify_expired_csr_deletion) {
     // Generate a CSR
-    std::string csr =
-        evse_security->generate_certificate_signing_request(LeafCertificateType::CSMS, "DE", "Pionix", "NA");
+    auto csr = evse_security->generate_certificate_signing_request(LeafCertificateType::CSMS, "DE", "Pionix", "NA");
     fs::path csr_key_path = evse_security->managed_csr.begin()->first;
 
     // Simulate a full fs else no deletion will take place


### PR DESCRIPTION
## Describe your changes

Updated the following:
- generate_csr_interface for clean handling
- handled some various unhandled errors
- updated return types
- removed OpenSSL warnings
- removed unnecessary test

## Issue ticket number and link

https://github.com/EVerest/libevse-security/issues/66

Supersedes: https://github.com/EVerest/libevse-security/pull/64 as it includes all changes placed there.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

