### PR TITLE
When veryfing a certificate the intermediary subcas

### DIFF
--- a/include/evse_security/crypto/interface/crypto_supplier.hpp
+++ b/include/evse_security/crypto/interface/crypto_supplier.hpp
@@ -57,11 +57,10 @@ public: // X509 certificate utilities
     /// @param dir_path     Optional directory path that can be used for certificate store lookup
     /// @param file_path    Optional certificate file path that can be used for certificate store lookup
     /// @return
-    static CertificateValidationResult x509_verify_certificate_chain(X509Handle* target,
-                                                                     const std::vector<X509Handle*>& parents,
-                                                                     bool allow_future_certificates,
-                                                                     const std::optional<fs::path> dir_path,
-                                                                     const std::optional<fs::path> file_path);
+    static CertificateValidationResult
+    x509_verify_certificate_chain(X509Handle* target, const std::vector<X509Handle*>& parents,
+                                  const std::vector<X509Handle*>& untrusted_subcas, bool allow_future_certificates,
+                                  const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path);
 
     /// @brief Checks if the private key is consistent with the provided handle
     static KeyValidationResult x509_check_private_key(X509Handle* handle, std::string private_key,

--- a/include/evse_security/crypto/openssl/openssl_supplier.hpp
+++ b/include/evse_security/crypto/openssl/openssl_supplier.hpp
@@ -31,11 +31,10 @@ public:
     static bool x509_is_child(X509Handle* child, X509Handle* parent);
     static bool x509_is_equal(X509Handle* a, X509Handle* b);
     static X509Handle_ptr x509_duplicate_unique(X509Handle* handle);
-    static CertificateValidationResult x509_verify_certificate_chain(X509Handle* target,
-                                                                     const std::vector<X509Handle*>& parents,
-                                                                     bool allow_future_certificates,
-                                                                     const std::optional<fs::path> dir_path,
-                                                                     const std::optional<fs::path> file_path);
+    static CertificateValidationResult
+    x509_verify_certificate_chain(X509Handle* target, const std::vector<X509Handle*>& parents,
+                                  const std::vector<X509Handle*>& untrusted_subcas, bool allow_future_certificates,
+                                  const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path);
     static KeyValidationResult x509_check_private_key(X509Handle* handle, std::string private_key,
                                                       std::optional<std::string> password);
     static bool x509_verify_signature(X509Handle* handle, const std::vector<std::byte>& signature,

--- a/include/evse_security/detail/openssl/openssl_types.hpp
+++ b/include/evse_security/detail/openssl/openssl_types.hpp
@@ -33,6 +33,13 @@ public:
     }
 };
 
+template <> class std::default_delete<STACK_OF(X509)> {
+public:
+    void operator()(STACK_OF(X509) * ptr) const {
+        sk_X509_free(ptr);
+    }
+};
+
 template <> class std::default_delete<EVP_PKEY> {
 public:
     void operator()(EVP_PKEY* ptr) const {
@@ -87,6 +94,9 @@ namespace evse_security {
 using X509_ptr = std::unique_ptr<X509>;
 using X509_STORE_ptr = std::unique_ptr<X509_STORE>;
 using X509_STORE_CTX_ptr = std::unique_ptr<X509_STORE_CTX>;
+// Unsafe since it does not free contained elements, only the stack, the element
+// cleanup has to be done manually
+using X509_STACK_UNSAFE_ptr = std::unique_ptr<STACK_OF(X509)>;
 using X509_REQ_ptr = std::unique_ptr<X509_REQ>;
 using EVP_PKEY_ptr = std::unique_ptr<EVP_PKEY>;
 using EVP_PKEY_CTX_ptr = std::unique_ptr<EVP_PKEY_CTX>;

--- a/lib/evse_security/crypto/interface/crypto_supplier.cpp
+++ b/lib/evse_security/crypto/interface/crypto_supplier.cpp
@@ -76,8 +76,8 @@ static X509Handle_ptr x509_duplicate_unique(X509Handle* handle) {
 }
 
 CertificateValidationResult AbstractCryptoSupplier::x509_verify_certificate_chain(
-    X509Handle* target, const std::vector<X509Handle*>& parents, bool allow_future_certificates,
-    const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path) {
+    X509Handle* target, const std::vector<X509Handle*>& parents, const std::vector<X509Handle*>& untrusted_subcas,
+    bool allow_future_certificates, const std::optional<fs::path> dir_path, const std::optional<fs::path> file_path) {
     default_crypto_supplier_usage_error() return CertificateValidationResult::Unknown;
 }
 

--- a/tests/openssl_supplier_test.cpp
+++ b/tests/openssl_supplier_test.cpp
@@ -91,13 +91,14 @@ TEST_F(OpenSSLSupplierTest, x509_verify_certificate_chain) {
     auto res_leaf = OpenSSLSupplier::load_certificates(cert_leaf, EncodingFormat::PEM);
 
     std::vector<X509Handle*> parents;
+    std::vector<X509Handle*> empty_untrusted;
 
     for (auto& i : res_path) {
         parents.push_back(i.get());
     }
 
-    auto res = OpenSSLSupplier::x509_verify_certificate_chain(res_leaf[0].get(), parents, true, std::nullopt,
-                                                              "pki/root_cert.pem");
+    auto res = OpenSSLSupplier::x509_verify_certificate_chain(res_leaf[0].get(), parents, empty_untrusted, true,
+                                                              std::nullopt, "pki/root_cert.pem");
     ASSERT_EQ(res, CertificateValidationResult::Valid);
 }
 


### PR DESCRIPTION
## Describe your changes

There was an issue during certificate verification, that presumed that intermediary certificates presented during either a leaf update or on a car certificate validation were trusted, which is not the case. The function 'x509_verify_certificate_chain' has been updated to reflect the correct functionality.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

