### PR TITLE
feat: expose OpenSSL handles so that other code can create objects

### DIFF
--- a/include/evse_security/detail/openssl/openssl_types.hpp
+++ b/include/evse_security/detail/openssl/openssl_types.hpp
@@ -90,4 +90,31 @@ using BIO_ptr = std::unique_ptr<BIO>;
 using EVP_MD_CTX_ptr = std::unique_ptr<EVP_MD_CTX>;
 using EVP_ENCODE_CTX_ptr = std::unique_ptr<EVP_ENCODE_CTX>;
 
+struct X509Handle;
+struct KeyHandle;
+
+struct X509HandleOpenSSL : public X509Handle {
+    X509HandleOpenSSL(X509* certificate) : x509(certificate) {
+    }
+
+    X509* get() {
+        return x509.get();
+    }
+
+private:
+    X509_ptr x509;
+};
+
+struct KeyHandleOpenSSL : public KeyHandle {
+    KeyHandleOpenSSL(EVP_PKEY* key) : key(key) {
+    }
+
+    EVP_PKEY* get() {
+        return key.get();
+    }
+
+private:
+    EVP_PKEY_ptr key;
+};
+
 } // namespace evse_security

--- a/lib/evse_security/crypto/openssl/openssl_supplier.cpp
+++ b/lib/evse_security/crypto/openssl/openssl_supplier.cpp
@@ -26,30 +26,6 @@
 
 namespace evse_security {
 
-struct X509HandleOpenSSL : public X509Handle {
-    X509HandleOpenSSL(X509* certificate) : x509(certificate) {
-    }
-
-    X509* get() {
-        return x509.get();
-    }
-
-private:
-    X509_ptr x509;
-};
-
-struct KeyHandleOpenSSL : public KeyHandle {
-    KeyHandleOpenSSL(EVP_PKEY* key) : key(key) {
-    }
-
-    EVP_PKEY* get() {
-        return key.get();
-    }
-
-private:
-    EVP_PKEY_ptr key;
-};
-
 static X509* get(X509Handle* handle) {
     if (X509HandleOpenSSL* ssl_handle = dynamic_cast<X509HandleOpenSSL*>(handle)) {
         return ssl_handle->get();


### PR DESCRIPTION
## Describe your changes

Previously X509HandleOpenSSL and KeyHandleOpenSSL were defined in openssl_supplier.cpp this made it difficult to create Handles from other OpenSSL code and use the methods in evse-security.


## Issue ticket number and link

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

