### PR TITLE
fix: catch directory not found when iterating over OCSP cache

### DIFF
--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -927,6 +927,8 @@ std::optional<fs::path> EvseSecurity::retrieve_ocsp_cache_internal(const Certifi
             }
         } catch (const NoCertificateFound& e) {
             EVLOG_error << "Could not find any certificate for ocsp cache retrieve: " << e.what();
+        } catch (const std::filesystem::filesystem_error& e) {
+            EVLOG_error << "Could not iterate over ocsp cache: " << e.what();
         }
     } catch (const CertificateLoadException& e) {
         EVLOG_error << "Could not retrieve ocsp cache, certificate load failure: " << e.what();


### PR DESCRIPTION
## Describe your changes

The code exceptions when there OCSP cache directory doesn't exist.
This fix catches the exception so that an error can be logged rather than terminating EVerest

example error prior to fix:
```
2024-06-17 10:48:57.318956 [INFO] evse_security:E  :: Found valid leaf: ["/home/james/code/everest/workspace/everest-core/build/dist/etc/everest/certs/client/cso/CPO_CERT_CHAIN.pem"]
terminate called after throwing an instance of 'std::filesystem::__cxx11::filesystem_error'
  what():  filesystem error: directory iterator cannot open directory: No such file or directory [/home/james/code/everest/workspace/everest-core/build/dist/etc/everest/certs/client/cso/ocsp]
2024-06-17 10:48:57.652987 [CRIT] manager         int boot(const boost::program_options::variables_map&) :: Module evse_security (pid: 59760) exited with status: 134. Terminating all modules.
2024-06-17 10:48:57.655044 [INFO] manager          :: SIGTERM of child: api (pid: 59755) succeeded.
...
```

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

