### PR TITLE
Multiple root trusted CA leafs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,9 @@ Defaults:
 - Minimum certificates kept: 10
 - Maximum storage space: 50 MB
 - Maximum certificate entries: 2000
+
+## Limitations
+
+Based on information from [ssl](https://www.ssl.com/article/what-are-root-certificates-and-why-do-they-matter/), self-signed roots are possible, but not supported in our library at the moment.
+
+Cross-signed certificate chains (see [ssl](https://www.ssl.com/blogs/ssl-com-legacy-cross-signed-root-certificate-expiring-on-september-11-2023/)), required for seamless root transitions are not supported at the moment.

--- a/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/include/evse_security/certificate/x509_hierarchy.hpp
@@ -57,6 +57,9 @@ public:
     /// @brief returns true if we contain a certificate with the following hash
     bool contains_certificate_hash(const CertificateHashData& hash);
 
+    /// @brief Searches for the root of the provided leaf, throwing a NoCertificateFound if not found
+    X509Wrapper find_certificate_root(const X509Wrapper& leaf);
+
     /// @brief Searches for the provided hash, throwing a NoCertificateFound if not found
     X509Wrapper find_certificate(const CertificateHashData& hash);
 

--- a/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/include/evse_security/certificate/x509_hierarchy.hpp
@@ -37,6 +37,7 @@ struct X509Node {
 
 /// @brief Utility class that is able to build a immutable certificate hierarchy
 /// with a  list of self-signed root certificates and their respective sub-certificates
+/// Note: non self-signed roots and cross-signed certificates are not supported now
 class X509CertificateHierarchy {
 public:
     const std::vector<X509Node>& get_hierarchy() const {

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -197,6 +197,24 @@ public:
     GetCertificateInfoResult get_leaf_certificate_info(LeafCertificateType certificate_type, EncodingFormat encoding,
                                                        bool include_ocsp = false);
 
+    /// @brief Finds the latest valid leafs, for each root certificate that is present on the filesystem, and
+    /// returns all the newest valid leafs that are present for different roots. This is required, because
+    /// a query parameter when requesting the leaf is not advisable during the TLS handshake
+    /// Existing filesystem:
+    /// ROOT_V2G_Hubject->SUB_CA1->SUB_CA2->Leaf_Invalid_A
+    /// ROOT_V2G_Hubject->SUB_CA1->SUB_CA2->Leaf_Valid_A
+    /// ROOT_V2G_Hubject->SUB_CA1->SUB_CA2->Leaf_Valid_B
+    /// ROOT_V2G_OtherProvider->SUB_CA_O1->SUB_CA_O2->Leav_Valid_A
+    /// will return:
+    /// ROOT_V2G_Hubject->SUB_CA1->SUB_CA2->Leaf_Valid_B +
+    /// ROOT_V2G_OtherProvider->SUB_CA_O1->SUB_CA_O2->Leav_Valid_A
+    /// @param certificate_type type of leaf certificate that we start the search from
+    /// @param encoding specifies PEM or DER format
+    /// @param include_ocsp if OCSP data should be included
+    /// @return contains response result, with info related to the full certificate chains info and response status
+    GetCertificateFullInfoResult get_all_valid_certificates_info(LeafCertificateType certificate_type,
+                                                                 EncodingFormat encoding, bool include_ocsp = false);
+
     /// @brief Checks and updates the symlinks for the V2G leaf certificates and keys to the most recent valid one
     /// @return true if one of the links was updated
     bool update_certificate_links(LeafCertificateType certificate_type);

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -272,8 +272,21 @@ private:
     // Internal versions of the functions do not lock the mutex
     CertificateValidationResult verify_certificate_internal(const std::string& certificate_chain,
                                                             LeafCertificateType certificate_type);
+
     GetCertificateInfoResult get_leaf_certificate_info_internal(LeafCertificateType certificate_type,
                                                                 EncodingFormat encoding, bool include_ocsp = false);
+
+    /// @brief Retrieves information related to leaf certificates
+    /// @param include_ocsp if OCSP information should be included
+    /// @param include_root if the root certificate of the leaf should be included in the returned list
+    /// @param include_all_valid if true, all valid leafs will be included, sorted in order, with the newest being
+    /// first. If false, only the newest one will be returned
+    GetCertificateFullInfoResult get_full_leaf_certificate_info_internal(LeafCertificateType certificate_type,
+                                                                         EncodingFormat encoding,
+                                                                         bool include_ocsp = false,
+                                                                         bool include_root = false,
+                                                                         bool include_all_valid = false);
+
     GetCertificateInfoResult get_ca_certificate_info_internal(CaCertificateType certificate_type);
     std::optional<fs::path> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
     bool is_ca_certificate_installed_internal(CaCertificateType certificate_type);

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -208,6 +208,7 @@ public:
     /// will return:
     /// ROOT_V2G_Hubject->SUB_CA1->SUB_CA2->Leaf_Valid_B +
     /// ROOT_V2G_OtherProvider->SUB_CA_O1->SUB_CA_O2->Leav_Valid_A
+    /// Note: non self-signed roots and cross-signed certificates are not supported
     /// @param certificate_type type of leaf certificate that we start the search from
     /// @param encoding specifies PEM or DER format
     /// @param include_ocsp if OCSP data should be included

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -143,10 +143,13 @@ struct CertificateOCSP {
 };
 
 struct CertificateInfo {
-    fs::path key;                               ///< The path of the PEM or DER encoded private key
-    std::optional<fs::path> certificate;        ///< The path of the PEM or DER encoded certificate chain if found
-    std::optional<fs::path> certificate_single; ///< The path of the PEM or DER encoded certificate if found
-    int certificate_count;               ///< The count of certificates, if the chain is available, or 1 if single
+    fs::path key;                                ///< The path of the PEM or DER encoded private key
+    std::optional<std::string> certificate_root; ///< The PEM of root certificate used by the leaf, has a value only
+                                                 /// when using 'get_all_valid_certificates_info'
+    std::optional<fs::path> certificate;         ///< The path of the PEM or DER encoded certificate chain if found
+    std::optional<fs::path> certificate_single;  ///< The path of the PEM or DER encoded single certificate if found
+    int leaf_certificate_count;          ///< The count of certificates, if the chain is available, or 1 if single
+                                         /// (the root is not taken into account because of the OCSP cache)
     std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
     std::vector<CertificateOCSP> ocsp;   ///< The ordered list of OCSP certificate data based on the chain file order
 };
@@ -154,6 +157,11 @@ struct CertificateInfo {
 struct GetCertificateInfoResult {
     GetCertificateInfoStatus status;
     std::optional<CertificateInfo> info;
+};
+
+struct GetCertificateFullInfoResult {
+    GetCertificateInfoStatus status;
+    std::vector<CertificateInfo> info;
 };
 
 struct GetCertificateSignRequestResult {

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -148,7 +148,7 @@ struct CertificateInfo {
                                                  /// when using 'get_all_valid_certificates_info'
     std::optional<fs::path> certificate;         ///< The path of the PEM or DER encoded certificate chain if found
     std::optional<fs::path> certificate_single;  ///< The path of the PEM or DER encoded single certificate if found
-    int leaf_certificate_count;          ///< The count of certificates, if the chain is available, or 1 if single
+    int certificate_count;               ///< The count of certificates, if the chain is available, or 1 if single
                                          /// (the root is not taken into account because of the OCSP cache)
     std::optional<std::string> password; ///< Specifies the password for the private key if encrypted
     std::vector<CertificateOCSP> ocsp;   ///< The ordered list of OCSP certificate data based on the chain file order

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -1086,6 +1086,42 @@ GetCertificateSignRequestResult EvseSecurity::generate_certificate_signing_reque
     return generate_certificate_signing_request(certificate_type, country, organization, common, false);
 }
 
+GetCertificateFullInfoResult EvseSecurity::get_all_valid_certificates_info(LeafCertificateType certificate_type,
+                                                                           EncodingFormat encoding, bool include_ocsp) {
+    std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
+
+    GetCertificateFullInfoResult result =
+        get_full_leaf_certificate_info_internal(certificate_type, encoding, include_ocsp, true, true);
+
+    // If we failed, simply return the result
+    if (result.status != GetCertificateInfoStatus::Accepted) {
+        return result;
+    }
+
+    GetCertificateFullInfoResult filtered_results;
+    filtered_results.status = result.status;
+
+    // Filter the certificates to return only the ones that have a unique
+    // root, and from those that have a unique root, return only the newest
+    std::set<std::string> unique_roots;
+
+    // The newest are the first, that's how 'get_leaf_certificate_info_internal'
+    // returns them
+    for (const auto& chain : result.info) {
+        const std::string& root = chain.certificate_root.value();
+
+        // If we don't contain the unique root yet, it is the newest leaf for that root
+        if (unique_roots.find(root) == unique_roots.end()) {
+            filtered_results.info.push_back(chain);
+
+            // Add it to the roots list, adding only unique roots
+            unique_roots.insert(root);
+        }
+    }
+
+    return filtered_results;
+}
+
 GetCertificateInfoResult EvseSecurity::get_leaf_certificate_info(LeafCertificateType certificate_type,
                                                                  EncodingFormat encoding, bool include_ocsp) {
     std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
@@ -1095,11 +1131,26 @@ GetCertificateInfoResult EvseSecurity::get_leaf_certificate_info(LeafCertificate
 
 GetCertificateInfoResult EvseSecurity::get_leaf_certificate_info_internal(LeafCertificateType certificate_type,
                                                                           EncodingFormat encoding, bool include_ocsp) {
+    GetCertificateFullInfoResult result =
+        get_full_leaf_certificate_info_internal(certificate_type, encoding, include_ocsp, false, false);
+    GetCertificateInfoResult internal_result;
+
+    internal_result.status = result.status;
+    if (!result.info.empty()) {
+        internal_result.info = std::move(result.info.at(0));
+    }
+
+    return internal_result;
+}
+
+GetCertificateFullInfoResult EvseSecurity::get_full_leaf_certificate_info_internal(LeafCertificateType certificate_type,
+                                                                                   EncodingFormat encoding,
+                                                                                   bool include_ocsp, bool include_root,
+                                                                                   bool include_all_valid) {
     EVLOG_info << "Requesting leaf certificate info: "
                << conversions::leaf_certificate_type_to_string(certificate_type);
 
-    GetCertificateInfoResult result;
-    result.info = std::nullopt;
+    GetCertificateFullInfoResult result;
 
     fs::path key_dir;
     fs::path cert_dir;
@@ -1131,26 +1182,43 @@ GetCertificateInfoResult EvseSecurity::get_leaf_certificate_info_internal(LeafCe
             return result;
         }
 
-        std::optional<X509Wrapper> latest_valid;
-        std::optional<fs::path> found_private_key_path;
+        struct KeyPairInternal {
+            X509Wrapper certificate;
+            fs::path certificate_key;
+        };
+
+        std::vector<KeyPairInternal> valid_leafs;
+
+        bool any_valid_certificate = false;
+        bool any_valid_key = false;
 
         // Iterate all certificates from newest to the oldest
         leaf_certificates.for_each_chain_ordered(
             [&](const fs::path& file, const std::vector<X509Wrapper>& chain) {
                 // Search for the first valid where we can find a key
                 if (not chain.empty() && chain.at(0).is_valid()) {
+                    any_valid_certificate = true;
+
                     try {
                         // Search for the private key
                         auto priv_key_path =
                             get_private_key_path_of_certificate(chain.at(0), key_dir, this->private_key_password);
 
+                        // Found at least one valid key
+                        any_valid_key = true;
+
                         // Copy to latest valid
-                        latest_valid = chain.at(0);
-                        found_private_key_path = priv_key_path;
+                        KeyPairInternal key_pair{chain.at(0), priv_key_path};
+                        valid_leafs.emplace_back(std::move(key_pair));
 
                         // We found, break
                         EVLOG_info << "Found valid leaf: [" << chain.at(0).get_file().value() << "]";
-                        return false;
+
+                        // Collect all if we don't include valid only
+                        if (include_all_valid == false) {
+                            EVLOG_info << "Not requiring all valid leafs, returning";
+                            return false;
+                        }
                     } catch (const NoPrivateKeyException& e) {
                     }
                 }
@@ -1166,122 +1234,154 @@ GetCertificateInfoResult EvseSecurity::get_leaf_certificate_info_internal(LeafCe
                 }
             });
 
-        if (latest_valid.has_value() == false) {
+        if (!any_valid_certificate) {
             EVLOG_warning << "Could not find valid certificate";
             result.status = GetCertificateInfoStatus::NotFoundValid;
             return result;
         }
 
-        if (found_private_key_path.has_value() == false) {
+        if (!any_valid_key) {
             EVLOG_warning << "Could not find private key for the valid certificate";
             result.status = GetCertificateInfoStatus::PrivateKeyNotFound;
             return result;
         }
 
-        // Key path doesn't change
-        fs::path key_file = found_private_key_path.value();
-        auto& certificate = latest_valid.value();
+        for (const auto& valid_leaf : valid_leafs) {
+            // Key path doesn't change
+            fs::path key_file = valid_leaf.certificate_key;
+            auto& certificate = valid_leaf.certificate;
 
-        // Paths to search
-        std::optional<fs::path> certificate_file;
-        std::optional<fs::path> chain_file;
+            // Paths to search
+            std::optional<fs::path> certificate_file;
+            std::optional<fs::path> chain_file;
 
-        X509CertificateBundle leaf_directory(cert_dir, EncodingFormat::PEM);
+            X509CertificateBundle leaf_directory(cert_dir, EncodingFormat::PEM);
 
-        const std::vector<X509Wrapper>* leaf_fullchain = nullptr;
-        const std::vector<X509Wrapper>* leaf_single = nullptr;
-        int chain_len = 1; // Defaults to 1, single certificate
+            const std::vector<X509Wrapper>* leaf_fullchain = nullptr;
+            const std::vector<X509Wrapper>* leaf_single = nullptr;
+            int chain_len = 1; // Defaults to 1, single certificate
 
-        // We are searching for both the full leaf bundle, containing the leaf and the cso1/2 and the single leaf
-        // without the cso1/2
-        leaf_directory.for_each_chain([&](const std::filesystem::path& path, const std::vector<X509Wrapper>& chain) {
-            // If we contain the latest valid, we found our generated bundle
-            bool bFound = (std::find(chain.begin(), chain.end(), certificate) != chain.end());
+            // We are searching for both the full leaf bundle, containing the leaf and the cso1/2 and the single leaf
+            // without the cso1/2
+            leaf_directory.for_each_chain(
+                [&](const std::filesystem::path& path, const std::vector<X509Wrapper>& chain) {
+                    // If we contain the latest valid, we found our generated bundle
+                    bool leaf_found = (std::find(chain.begin(), chain.end(), certificate) != chain.end());
 
-            if (bFound) {
-                if (chain.size() > 1) {
-                    leaf_fullchain = &chain;
-                    chain_len = chain.size();
-                } else if (chain.size() == 1) {
-                    leaf_single = &chain;
-                }
+                    if (leaf_found) {
+                        if (chain.size() > 1) {
+                            leaf_fullchain = &chain;
+                            chain_len = chain.size();
+                        } else if (chain.size() == 1) {
+                            leaf_single = &chain;
+                        }
+                    }
+
+                    // Found both, break
+                    if (leaf_fullchain != nullptr && leaf_single != nullptr)
+                        return false;
+
+                    return true;
+                });
+
+            std::vector<CertificateOCSP> certificate_ocsp{};
+            std::optional<std::string> leafs_root = std::nullopt;
+
+            // None were found
+            if (leaf_single == nullptr && leaf_fullchain == nullptr) {
+                EVLOG_error << "Could not find any leaf certificate for:"
+                            << conversions::leaf_certificate_type_to_string(certificate_type);
+                // Move onto next valid leaf, and attempt a search there
+                continue;
             }
 
-            // Found both, break
-            if (leaf_fullchain != nullptr && leaf_single != nullptr)
-                return false;
-
-            return true;
-        });
-
-        std::vector<CertificateOCSP> certificate_ocsp{};
-
-        // None were found
-        if (leaf_single == nullptr && leaf_fullchain == nullptr) {
-            EVLOG_error << "Could not find any leaf certificate for:"
-                        << conversions::leaf_certificate_type_to_string(certificate_type);
-
-            result.status = GetCertificateInfoStatus::NotFound;
-            return result;
-        }
-
-        if (leaf_fullchain != nullptr) {
-            chain_file = leaf_fullchain->at(0).get_file();
-            EVLOG_debug << "Leaf fullchain: [" << chain_file.value_or("INVALID") << "]";
-        } else {
-            EVLOG_warning << conversions::leaf_certificate_type_to_string(certificate_type)
-                          << " leaf requires full bundle, but full bundle not found at path: " << cert_dir;
-        }
-
-        if (leaf_single != nullptr) {
-            certificate_file = leaf_single->at(0).get_file();
-            EVLOG_debug << "Leaf single: [" << certificate_file.value_or("INVALID") << "]";
-        } else {
-            EVLOG_warning << conversions::leaf_certificate_type_to_string(certificate_type)
-                          << " single leaf not found at path: " << cert_dir;
-        }
-
-        // Include OCSP data if possible
-        if (include_ocsp && (leaf_fullchain != nullptr || leaf_single != nullptr)) {
-            X509CertificateBundle root_bundle(root_dir, EncodingFormat::PEM); // Required for hierarchy
-
-            auto hierarchy =
-                std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_directory.split()));
-            EVLOG_debug << "Hierarchy for OCSP data: \n" << hierarchy.to_debug_string();
-
-            // Search for OCSP data for each certificate
             if (leaf_fullchain != nullptr) {
-                for (const auto& chain_certif : *leaf_fullchain) {
-                    try {
-                        CertificateHashData hash = hierarchy.get_certificate_hash(chain_certif);
-                        std::optional<fs::path> data = retrieve_ocsp_cache_internal(hash);
+                chain_file = leaf_fullchain->at(0).get_file();
+                EVLOG_debug << "Leaf fullchain: [" << chain_file.value_or("INVALID") << "]";
+            } else {
+                EVLOG_debug << conversions::leaf_certificate_type_to_string(certificate_type)
+                            << " leaf requires full bundle, but full bundle not found at path: " << cert_dir;
+            }
 
-                        certificate_ocsp.push_back({hash, data});
-                    } catch (const NoCertificateFound& e) {
-                        // Always add to preserve file order
-                        certificate_ocsp.push_back({{}, std::nullopt});
+            if (leaf_single != nullptr) {
+                certificate_file = leaf_single->at(0).get_file();
+                EVLOG_debug << "Leaf single: [" << certificate_file.value_or("INVALID") << "]";
+            } else {
+                EVLOG_debug << conversions::leaf_certificate_type_to_string(certificate_type)
+                            << " single leaf not found at path: " << cert_dir;
+            }
+
+            // Both require the hierarchy build
+            if (include_ocsp || include_root) {
+                X509CertificateBundle root_bundle(root_dir, EncodingFormat::PEM); // Required for hierarchy
+
+                // The hierarchy is required for both roots and the OCSP cache
+                auto hierarchy =
+                    std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_directory.split()));
+                EVLOG_debug << "Hierarchy for root/OCSP data: \n" << hierarchy.to_debug_string();
+
+                // Include OCSP data if possible
+                if (include_ocsp) {
+                    // Search for OCSP data for each certificate
+                    if (leaf_fullchain != nullptr) {
+                        for (const auto& chain_certif : *leaf_fullchain) {
+                            try {
+                                CertificateHashData hash = hierarchy.get_certificate_hash(chain_certif);
+                                std::optional<fs::path> data = retrieve_ocsp_cache_internal(hash);
+
+                                certificate_ocsp.push_back({hash, data});
+                            } catch (const NoCertificateFound& e) {
+                                // Always add to preserve file order
+                                certificate_ocsp.push_back({{}, std::nullopt});
+                            }
+                        }
+                    } else {
+                        try {
+                            CertificateHashData hash = hierarchy.get_certificate_hash(leaf_single->at(0));
+                            certificate_ocsp.push_back({hash, retrieve_ocsp_cache_internal(hash)});
+                        } catch (const NoCertificateFound& e) {
+                        }
                     }
                 }
-            } else {
-                try {
-                    CertificateHashData hash = hierarchy.get_certificate_hash(leaf_single->at(0));
-                    certificate_ocsp.push_back({hash, retrieve_ocsp_cache_internal(hash)});
-                } catch (const NoCertificateFound& e) {
+
+                // Include root data if possible
+                if (include_root) {
+                    // Search for the root of any of the leafs
+                    // present either in the chain or single
+                    try {
+                        X509Wrapper leafs_root_cert = hierarchy.find_certificate_root(
+                            leaf_fullchain != nullptr ? leaf_fullchain->at(0) : leaf_single->at(0));
+
+                        // Append the root
+                        leafs_root = leafs_root_cert.get_export_string();
+                    } catch (const NoCertificateFound& e) {
+                        EVLOG_warning << "Root required for ["
+                                      << conversions::leaf_certificate_type_to_string(certificate_type)
+                                      << "] leaf certificate, but no root could be found";
+                    }
                 }
             }
-        }
 
-        CertificateInfo info;
+            CertificateInfo info;
 
-        info.key = key_file;
-        info.certificate = chain_file;
-        info.certificate_single = certificate_file;
-        info.certificate_count = chain_len;
-        info.password = this->private_key_password;
-        info.ocsp = certificate_ocsp;
+            info.key = key_file;
+            info.certificate = chain_file;
+            info.certificate_single = certificate_file;
+            info.certificate_count = chain_len;
+            info.password = this->private_key_password;
 
-        result.info = info;
-        result.status = GetCertificateInfoStatus::Accepted;
+            if (include_ocsp) {
+                info.ocsp = certificate_ocsp;
+            }
+
+            if (include_root && leafs_root.has_value()) {
+                info.certificate_root = leafs_root.value();
+            }
+
+            // Add it to the returned result list
+            result.info.push_back(info);
+            result.status = GetCertificateInfoStatus::Accepted;
+        } // End valid leaf iteration
 
         return result;
     } catch (const CertificateLoadException& e) {

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -1321,8 +1321,7 @@ GetCertificateFullInfoResult EvseSecurity::get_full_leaf_certificate_info_intern
                 X509CertificateBundle root_bundle(root_dir, EncodingFormat::PEM); // Required for hierarchy
 
                 // The hierarchy is required for both roots and the OCSP cache
-                auto hierarchy =
-                    std::move(X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_directory.split()));
+                auto hierarchy = X509CertificateHierarchy::build_hierarchy(root_bundle.split(), leaf_directory.split());
                 EVLOG_debug << "Hierarchy for root/OCSP data: \n" << hierarchy.to_debug_string();
 
                 // Include OCSP data if possible

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -1108,6 +1108,11 @@ GetCertificateFullInfoResult EvseSecurity::get_all_valid_certificates_info(LeafC
     // The newest are the first, that's how 'get_leaf_certificate_info_internal'
     // returns them
     for (const auto& chain : result.info) {
+        // Ignore non-root items
+        if(!chain.certificate_root.has_value()) {
+            continue;
+        }
+
         const std::string& root = chain.certificate_root.value();
 
         // If we don't contain the unique root yet, it is the newest leaf for that root

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -1109,7 +1109,7 @@ GetCertificateFullInfoResult EvseSecurity::get_all_valid_certificates_info(LeafC
     // returns them
     for (const auto& chain : result.info) {
         // Ignore non-root items
-        if(!chain.certificate_root.has_value()) {
+        if (!chain.certificate_root.has_value()) {
             continue;
         }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})
 
 install(
     PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_certs.sh"
+    PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/generate_test_certs_multi.sh"
     DESTINATION "${CMAKE_BINARY_DIR}/tests"
 )
 

--- a/tests/configs/seccLeafCert_Alternate.cnf
+++ b/tests/configs/seccLeafCert_Alternate.cnf
@@ -1,0 +1,15 @@
+[req]
+prompt 					= no
+distinguished_name		= ca_dn
+
+[ca_dn]
+commonName				= SECCGridSyncCert
+organizationName		= GridSync
+countryName				= DE
+domainComponent			= CPO
+
+[ext]
+basicConstraints		= critical,CA:false
+keyUsage				= critical,digitalSignature,keyAgreement
+subjectKeyIdentifier	= hash
+

--- a/tests/configs/v2gRootCACert_Alternate.cnf
+++ b/tests/configs/v2gRootCACert_Alternate.cnf
@@ -1,0 +1,15 @@
+[req]
+prompt 					= no
+distinguished_name		= ca_dn
+
+[ca_dn]
+commonName				= V2GRootGridSyncCA
+organizationName		= GridSync
+countryName				= DE
+domainComponent			= V2G
+
+[ext]
+basicConstraints		= critical,CA:true
+keyUsage				= critical,keyCertSign,cRLSign
+subjectKeyIdentifier	= hash
+

--- a/tests/generate_test_certs.sh
+++ b/tests/generate_test_certs.sh
@@ -74,8 +74,13 @@ create_certificate SECC_LEAF "${CLIENT_CSO_PATH}" seccLeafCert.cnf 12348 "${CA_C
 # Invalid self-signed CSMS cert
 create_certificate INVALID_CSMS "${CLIENT_INVALID_PATH}" v2gRootCACert.cnf 12345
 
+# V2G alternate root CA
+create_certificate V2G_ROOT_GRIDSYNC_CA "${CA_V2G_PATH}" v2gRootCACert_Alternate.cnf 12345
+# Alternate chargepoint leaf
+create_certificate SECC_LEAF_GRIDSYNC "${CLIENT_CSMS_PATH}" seccLeafCert_Alternate.cnf 12348 "${CA_V2G_PATH}/V2G_ROOT_GRIDSYNC_CA.pem" "${CA_V2G_PATH}/V2G_ROOT_GRIDSYNC_CA.key"
+
 # create cert chain bundles in the V2G root ca and chargepoint leaf dirs
-cat "$CA_CSMS_PATH/CPO_SUB_CA2.pem" "$CA_CSMS_PATH/CPO_SUB_CA1.pem" "$CA_V2G_PATH/V2G_ROOT_CA.pem" > "$CA_V2G_PATH/V2G_CA_BUNDLE.pem"
+cat "$CA_CSMS_PATH/CPO_SUB_CA2.pem" "$CA_CSMS_PATH/CPO_SUB_CA1.pem" "$CA_V2G_PATH/V2G_ROOT_CA.pem" "$CA_V2G_PATH/V2G_ROOT_GRIDSYNC_CA.pem" > "$CA_V2G_PATH/V2G_CA_BUNDLE.pem"
 cat "$CLIENT_CSO_PATH/SECC_LEAF.pem" "$CA_CSMS_PATH/CPO_SUB_CA2.pem" "$CA_CSMS_PATH/CPO_SUB_CA1.pem" > "$CLIENT_CSO_PATH/CPO_CERT_CHAIN.pem"
 
 cp "$CLIENT_CSO_PATH/SECC_LEAF.key" "$CLIENT_CSMS_PATH/CSMS_LEAF.key"

--- a/tests/generate_test_certs_multi.sh
+++ b/tests/generate_test_certs_multi.sh
@@ -74,8 +74,13 @@ create_certificate SECC_LEAF "${CLIENT_CSO_PATH}" seccLeafCert.cnf 12348 "${CA_C
 # Invalid self-signed CSMS cert
 create_certificate INVALID_CSMS "${CLIENT_INVALID_PATH}" v2gRootCACert.cnf 12345
 
+# V2G alternate root CA
+create_certificate V2G_ROOT_GRIDSYNC_CA "${CA_V2G_PATH}" v2gRootCACert_Alternate.cnf 12345
+# Alternate chargepoint leaf
+create_certificate SECC_LEAF_GRIDSYNC "${CLIENT_CSMS_PATH}" seccLeafCert_Alternate.cnf 12348 "${CA_V2G_PATH}/V2G_ROOT_GRIDSYNC_CA.pem" "${CA_V2G_PATH}/V2G_ROOT_GRIDSYNC_CA.key"
+
 # create cert chain bundles in the V2G root ca and chargepoint leaf dirs
-cat "$CA_CSMS_PATH/CPO_SUB_CA2.pem" "$CA_CSMS_PATH/CPO_SUB_CA1.pem" "$CA_V2G_PATH/V2G_ROOT_CA.pem" > "$CA_V2G_PATH/V2G_CA_BUNDLE.pem"
+cat "$CA_CSMS_PATH/CPO_SUB_CA2.pem" "$CA_CSMS_PATH/CPO_SUB_CA1.pem" "$CA_V2G_PATH/V2G_ROOT_CA.pem" "$CA_V2G_PATH/V2G_ROOT_GRIDSYNC_CA.pem" > "$CA_V2G_PATH/V2G_CA_BUNDLE.pem"
 cat "$CLIENT_CSO_PATH/SECC_LEAF.pem" "$CA_CSMS_PATH/CPO_SUB_CA2.pem" "$CA_CSMS_PATH/CPO_SUB_CA1.pem" > "$CLIENT_CSO_PATH/CPO_CERT_CHAIN.pem"
 
 cp "$CLIENT_CSO_PATH/SECC_LEAF.key" "$CLIENT_CSMS_PATH/CSMS_LEAF.key"

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -88,12 +88,11 @@ protected:
     }
 };
 
-
 class EvseSecurityTestsMulti : public EvseSecurityTests {
-protected:    
+protected:
     void install_certs() override {
         std::system("./generate_test_certs_multi.sh");
-    }    
+    }
 };
 
 class EvseSecurityTestsExpired : public EvseSecurityTests {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -174,7 +174,11 @@ protected:
 };
 
 TEST_F(EvseSecurityTests, verify_multi_root_leaf_retrieval) {
+    auto result = this->evse_security->get_all_valid_certificates_info(LeafCertificateType::CSMS, EncodingFormat::PEM, false);
 
+    ASSERT_EQ(result.status, GetCertificateInfoStatus::Accepted);
+
+    std::cout << "Result size: " << result.info.size();
 }
 
 TEST_F(EvseSecurityTests, verify_basics) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -50,10 +50,6 @@ bool equal_certificate_strings(const std::string& cert1, const std::string& cert
     return true;
 }
 
-void install_certs() {
-    std::system("./generate_test_certs.sh");
-}
-
 namespace evse_security {
 
 class EvseSecurityTests : public ::testing::Test {
@@ -86,6 +82,18 @@ protected:
         fs::remove_all("certs");
         fs::remove_all("csr");
     }
+
+    virtual void install_certs() {
+        std::system("./generate_test_certs.sh");
+    }
+};
+
+
+class EvseSecurityTestsMulti : public EvseSecurityTests {
+protected:    
+    void install_certs() override {
+        std::system("./generate_test_certs_multi.sh");
+    }    
 };
 
 class EvseSecurityTestsExpired : public EvseSecurityTests {
@@ -172,14 +180,6 @@ protected:
         fs::remove_all("expired_bulk");
     }
 };
-
-TEST_F(EvseSecurityTests, verify_multi_root_leaf_retrieval) {
-    auto result = this->evse_security->get_all_valid_certificates_info(LeafCertificateType::CSMS, EncodingFormat::PEM, false);
-
-    ASSERT_EQ(result.status, GetCertificateInfoStatus::Accepted);
-
-    std::cout << "Result size: " << result.info.size();
-}
 
 TEST_F(EvseSecurityTests, verify_basics) {
     const char* bundle_path = "certs/ca/v2g/V2G_CA_BUNDLE.pem";
@@ -278,6 +278,27 @@ TEST_F(EvseSecurityTests, verify_certificate_counts) {
     ASSERT_EQ(this->evse_security->get_count_of_installed_certificates({CertificateType::MFRootCertificate}), 3);
     // None were defined
     ASSERT_EQ(this->evse_security->get_count_of_installed_certificates({CertificateType::MORootCertificate}), 0);
+}
+
+TEST_F(EvseSecurityTestsMulti, verify_multi_root_leaf_retrieval) {
+    auto result =
+        this->evse_security->get_all_valid_certificates_info(LeafCertificateType::CSMS, EncodingFormat::PEM, false);
+
+    ASSERT_EQ(result.status, GetCertificateInfoStatus::Accepted);
+
+    // We have 2 leafs
+    ASSERT_EQ(result.info.size(), 2);
+
+    ASSERT_EQ(fs::path("certs/client/csms/CSMS_LEAF.pem"), result.info[0].certificate_single.value());
+    ASSERT_EQ(fs::path("certs/client/csms/SECC_LEAF_GRIDSYNC.pem"), result.info[1].certificate_single.value());
+
+    ASSERT_TRUE(result.info[0].certificate_root.has_value());
+    ASSERT_TRUE(result.info[1].certificate_root.has_value());
+
+    ASSERT_TRUE(equal_certificate_strings(result.info[0].certificate_root.value(),
+                                          read_file_to_string("certs/ca/v2g/V2G_ROOT_CA.pem")));
+    ASSERT_TRUE(equal_certificate_strings(result.info[1].certificate_root.value(),
+                                          read_file_to_string("certs/ca/v2g/V2G_ROOT_GRIDSYNC_CA.pem")));
 }
 
 TEST_F(EvseSecurityTests, verify_normal_keygen) {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -173,6 +173,10 @@ protected:
     }
 };
 
+TEST_F(EvseSecurityTests, verify_multi_root_leaf_retrieval) {
+
+}
+
 TEST_F(EvseSecurityTests, verify_basics) {
     const char* bundle_path = "certs/ca/v2g/V2G_CA_BUNDLE.pem";
 


### PR DESCRIPTION
## Describe your changes

Introduces one API call that allows the retrieval of the retrieval of multiple leaf certificate chains, that are linked to different roots. 

## Issue ticket number and link

Core related branch: https://github.com/EVerest/everest-core/tree/feature/multi_root_trusted_ca

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

