### PR TITLE
Fixed bug in return certificate order for V2GChertificateChain

### DIFF
--- a/include/evse_security/certificate/x509_wrapper.hpp
+++ b/include/evse_security/certificate/x509_wrapper.hpp
@@ -134,6 +134,10 @@ private:
 
     // Relevant file in which this certificate resides
     std::optional<fs::path> file;
+
+#ifdef DEBUG_MODE_EVSE_SECURITY
+    std::string debug_common_name;
+#endif
 };
 
 } // namespace evse_security

--- a/include/evse_security/evse_types.hpp
+++ b/include/evse_security/evse_types.hpp
@@ -120,6 +120,10 @@ struct CertificateHashData {
     std::string serial_number; ///< The string representation of the hexadecimal value of the serial number without the
                                ///< prefix "0x" and without leading zeroes.
 
+#ifdef DEBUG_MODE_EVSE_SECURITY
+    std::string debug_common_name; ///< Common name for easy debug
+#endif
+
     bool operator==(const CertificateHashData& Other) const {
         return hash_algorithm == Other.hash_algorithm && issuer_name_hash == Other.issuer_name_hash &&
                issuer_key_hash == Other.issuer_key_hash && serial_number == Other.serial_number;

--- a/lib/evse_security/CMakeLists.txt
+++ b/lib/evse_security/CMakeLists.txt
@@ -78,6 +78,12 @@ target_link_libraries(evse_security
         OpenSSL::Crypto
 )
 
+if(LIBEVSE_SECURITY_BUILD_TESTING)
+    target_compile_definitions(evse_security PRIVATE
+        DEBUG_MODE_EVSE_SECURITY       
+    )
+endif()
+
 if(LIBEVSE_SECURITY_USE_BOOST_FILESYSTEM)
     find_package(Boost REQUIRED COMPONENTS filesystem)
     target_link_libraries(evse_security

--- a/lib/evse_security/certificate/x509_bundle.cpp
+++ b/lib/evse_security/certificate/x509_bundle.cpp
@@ -54,17 +54,19 @@ X509CertificateBundle::X509CertificateBundle(const fs::path& path, const Encodin
         // Iterate directory
         for (const auto& entry : fs::recursive_directory_iterator(path)) {
             if (is_certificate_file(entry)) {
-                std::string certificate;
-                if (filesystem_utils::read_from_file(entry.path(), certificate))
+                std::string certificate{};
+                if (filesystem_utils::read_from_file(entry.path(), certificate)) {
                     add_certificates(certificate, encoding, entry.path());
+                }
             }
         }
     } else if (is_certificate_file(path)) {
         source = X509CertificateSource::FILE;
 
-        std::string certificate;
-        if (filesystem_utils::read_from_file(path, certificate))
+        std::string certificate{};
+        if (filesystem_utils::read_from_file(path, certificate)) {
             add_certificates(certificate, encoding, path);
+        }
     } else {
         throw CertificateLoadException("Failed to create certificate info from path: " + path.string());
     }

--- a/lib/evse_security/certificate/x509_wrapper.cpp
+++ b/lib/evse_security/certificate/x509_wrapper.cpp
@@ -64,6 +64,9 @@ X509Wrapper::X509Wrapper(const X509Wrapper& other) :
     file(other.file),
     valid_in(other.valid_in),
     valid_to(other.valid_to) {
+#ifdef DEBUG_MODE_EVSE_SECURITY
+    debug_common_name = other.debug_common_name;
+#endif
 }
 
 X509Wrapper::~X509Wrapper() {
@@ -80,6 +83,10 @@ void X509Wrapper::update_validity() {
     if (false == CryptoSupplier::x509_get_validity(get(), valid_in, valid_to)) {
         EVLOG_error << "Could not update validity for certificate: " << get_common_name();
     }
+
+#ifdef DEBUG_MODE_EVSE_SECURITY
+    debug_common_name = get_common_name();
+#endif
 }
 
 bool X509Wrapper::is_child(const X509Wrapper& parent) const {
@@ -162,6 +169,11 @@ CertificateHashData X509Wrapper::get_certificate_hash_data() const {
     certificate_hash_data.issuer_name_hash = this->get_issuer_name_hash();
     certificate_hash_data.issuer_key_hash = this->get_issuer_key_hash();
     certificate_hash_data.serial_number = this->get_serial_number();
+
+#ifdef DEBUG_MODE_EVSE_SECURITY
+    certificate_hash_data.debug_common_name = this->get_common_name();
+#endif
+
     return certificate_hash_data;
 }
 
@@ -182,6 +194,10 @@ CertificateHashData X509Wrapper::get_certificate_hash_data(const X509Wrapper& is
     // Issuer key hash
     certificate_hash_data.issuer_key_hash = issuer.get_key_hash();
     certificate_hash_data.serial_number = this->get_serial_number();
+
+#ifdef DEBUG_MODE_EVSE_SECURITY
+    certificate_hash_data.debug_common_name = this->get_common_name();
+#endif
 
     return certificate_hash_data;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ if(LIBEVSE_CRYPTO_SUPPLIER_OPENSSL)
 endif()
 
 add_compile_definitions(BUILD_TESTING_EVSE_SECURITY)
+add_compile_definitions(DEBUG_MODE_EVSE_SECURITY)
 
 add_test(${TEST_TARGET_NAME} ${TEST_TARGET_NAME})
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -667,6 +667,24 @@ TEST_F(EvseSecurityTests, delete_sub_ca_2) {
               certs_after_delete.end());
 }
 
+TEST_F(EvseSecurityTests, get_installed_certificates_chain_order) {
+    std::vector<CertificateType> certificate_types;
+    certificate_types.push_back(CertificateType::V2GCertificateChain);
+
+    const auto r = this->evse_security->get_installed_certificates(certificate_types);
+
+    ASSERT_EQ(r.status, GetInstalledCertificatesStatus::Accepted);
+    ASSERT_EQ(r.certificate_hash_data_chain.size(), 1);
+
+    auto& v2g_chain = r.certificate_hash_data_chain.front();
+
+    // Assert the order with the SECCLeaf first
+    ASSERT_EQ(v2g_chain.certificate_hash_data.debug_common_name, std::string("SECCCert"));
+    ASSERT_EQ(v2g_chain.child_certificate_hash_data.size(), 2);
+    ASSERT_EQ(v2g_chain.child_certificate_hash_data[0].debug_common_name, std::string("CPOSubCA2"));
+    ASSERT_EQ(v2g_chain.child_certificate_hash_data[1].debug_common_name, std::string("CPOSubCA1"));
+}
+
 TEST_F(EvseSecurityTests, get_installed_certificates_and_delete_secc_leaf) {
     std::vector<CertificateType> certificate_types;
     certificate_types.push_back(CertificateType::V2GRootCertificate);


### PR DESCRIPTION
## Describe your changes

- Added extra information for debug build for easy hierarchy inspection
- Fixed certificate return order for V2GCertificateChain from Leaf->Sec1->Sec2 to Leaf->Sec2->Sec1

## Issue ticket number and link

Closes: https://github.com/EVerest/libevse-security/issues/102

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

