### PR TITLE
Certificate Verification: Multiple trust anchors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(everest-evse_security VERSION 0.9.4
+project(everest-evse_security VERSION 0.9.5
         DESCRIPTION "Implementation of EVSE related security operations"
 		LANGUAGES CXX C
 )

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -110,13 +110,21 @@ public:
     /// @return result of the operation
     DeleteCertificateResult delete_certificate(const CertificateHashData& certificate_hash_data);
 
-    /// @brief Verifies the given \p certificate_chain for the given \p certificate_type against the respective CA
-    /// certificates for the leaf.
+    /// @brief Verifies the given \p certificate_chain against the respective CA
+    /// trust anchors (indicated by the given \p certificate_type) for the leaf.
     /// @param certificate_chain PEM formatted certificate or certificate chain
     /// @param certificate_type type of the root certificate for which the chain is verified
     /// @return result of the operation
     CertificateValidationResult verify_certificate(const std::string& certificate_chain,
                                                    const LeafCertificateType certificate_type);
+
+    /// @brief Verifies the given \p certificate_chain against the respective CA
+    /// trust anchors (indicated by the given \p certificate_types) for the leaf.
+    /// @param certificate_chain PEM formatted certificate or certificate chain
+    /// @param certificate_types types of the root certificates for which the chain is verified
+    /// @return result of the operation
+    CertificateValidationResult verify_certificate(const std::string& certificate_chain,
+                                                   const std::vector<LeafCertificateType>& certificate_types);
 
     /// @brief Verifies the given \p certificate_chain for the given \p certificate_type against the respective CA
     /// certificates for the leaf and if valid installs the certificate on the filesystem. Before installing on the
@@ -297,7 +305,7 @@ public:
 private:
     // Internal versions of the functions do not lock the mutex
     CertificateValidationResult verify_certificate_internal(const std::string& certificate_chain,
-                                                            LeafCertificateType certificate_type);
+                                                            const std::vector<LeafCertificateType>& certificate_types);
 
     GetCertificateInfoResult get_leaf_certificate_info_internal(LeafCertificateType certificate_type,
                                                                 EncodingFormat encoding, bool include_ocsp = false);

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -480,7 +480,7 @@ InstallCertificateResult EvseSecurity::update_leaf_certificate(const std::string
         }
 
         // Internal since we already acquired the lock
-        const auto result = this->verify_certificate_internal(certificate_chain, certificate_type);
+        const auto result = this->verify_certificate_internal(certificate_chain, {certificate_type});
         if (result != CertificateValidationResult::Valid) {
             return to_install_certificate_result(result);
         }
@@ -1738,29 +1738,48 @@ CertificateValidationResult EvseSecurity::verify_certificate(const std::string& 
                                                              LeafCertificateType certificate_type) {
     std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
 
-    return verify_certificate_internal(certificate_chain, certificate_type);
+    return verify_certificate_internal(certificate_chain, {certificate_type});
 }
 
-CertificateValidationResult EvseSecurity::verify_certificate_internal(const std::string& certificate_chain,
-                                                                      LeafCertificateType certificate_type) {
-    EVLOG_info << "Verifying leaf certificate: " << conversions::leaf_certificate_type_to_string(certificate_type);
+CertificateValidationResult
+EvseSecurity::verify_certificate(const std::string& certificate_chain,
+                                 const std::vector<LeafCertificateType>& certificate_types) {
+    return verify_certificate_internal(certificate_chain, certificate_types);
+}
 
-    CaCertificateType ca_certificate_type;
+CertificateValidationResult
+EvseSecurity::verify_certificate_internal(const std::string& certificate_chain,
+                                          const std::vector<LeafCertificateType>& certificate_types) {
 
-    if (certificate_type == LeafCertificateType::CSMS) {
-        ca_certificate_type = CaCertificateType::CSMS;
-    } else if (certificate_type == LeafCertificateType::V2G) {
-        ca_certificate_type = CaCertificateType::V2G;
-    } else if (certificate_type == LeafCertificateType::MF)
-        ca_certificate_type = CaCertificateType::MF;
-    else if (certificate_type == LeafCertificateType::MO) {
-        ca_certificate_type = CaCertificateType::MO;
-    } else {
-        throw std::runtime_error("Could not convert LeafCertificateType to CaCertificateType during verification!");
+    EVLOG_info << "Verifying leaf certificate";
+
+    std::set<CaCertificateType> ca_certificate_types;
+
+    for (const auto& cert_type : certificate_types) {
+        EVLOG_info << "Including trust anchor for leaf certificate: "
+                   << conversions::leaf_certificate_type_to_string(cert_type);
+
+        switch (cert_type) {
+        case LeafCertificateType::CSMS:
+            ca_certificate_types.insert(CaCertificateType::CSMS);
+            break;
+        case LeafCertificateType::V2G:
+            ca_certificate_types.insert(CaCertificateType::V2G);
+            break;
+        case LeafCertificateType::MF:
+            ca_certificate_types.insert(CaCertificateType::MF);
+            break;
+        case LeafCertificateType::MO:
+            ca_certificate_types.insert(CaCertificateType::MO);
+            break;
+        default:
+            EVLOG_warning << "Unknown LeafCertificateType provided. Skipping.";
+            break;
+        }
     }
 
-    // If we don't have a root certificate installed, return that we can't find an issuer
-    if (false == is_ca_certificate_installed_internal(ca_certificate_type)) {
+    if (ca_certificate_types.empty()) {
+        EVLOG_warning << "No valid CA certificate types could be determined from leaf types.";
         return CertificateValidationResult::IssuerNotFound;
     }
 
@@ -1794,36 +1813,47 @@ CertificateValidationResult EvseSecurity::verify_certificate_internal(const std:
         }
 
         // Build the trusted parent certificates from our internal store
+        std::vector<X509Wrapper> trusted_wrappers;
         std::vector<X509Handle*> trusted_parent_certificates;
 
-        fs::path root_store = this->ca_bundle_path_map.at(ca_certificate_type);
-        CertificateValidationResult validated{};
-
-        if (fs::is_directory(root_store)) {
-            // In case of a directory load the certificates manually and add them
-            // to the parent certificates
-            X509CertificateBundle roots(root_store, EncodingFormat::PEM);
-
-            // We use a root chain instead of relying on OpenSSL since that requires to have
-            // the name of the certificates in the format "hash.0", hash being the subject hash
-            // or to have symlinks in the mentioned format to the certificates in the directory
-            std::vector<X509Wrapper> root_chain{roots.split()};
-
-            for (size_t i = 0; i < root_chain.size(); i++) {
-                trusted_parent_certificates.emplace_back(root_chain[i].get());
+        for (const auto& ca_type : ca_certificate_types) {
+            if (!is_ca_certificate_installed_internal(ca_type)) {
+                continue;
             }
 
-            // The root_chain stores the X509Handler pointers, if this goes out of scope then
-            // parent_certificates will point to nothing.
-            validated =
-                CryptoSupplier::x509_verify_certificate_chain(leaf_certificate.get(), trusted_parent_certificates,
-                                                              untrusted_subcas, true, std::nullopt, std::nullopt);
-        } else {
-            validated = CryptoSupplier::x509_verify_certificate_chain(
-                leaf_certificate.get(), trusted_parent_certificates, untrusted_subcas, true, std::nullopt, root_store);
+            const auto root_store = this->ca_bundle_path_map.at(ca_type);
+            if (fs::is_directory(root_store)) {
+                // In case of a directory load the certificates manually and add them
+                // to the parent certificates
+                X509CertificateBundle roots(root_store, EncodingFormat::PEM);
+
+                // We use a root chain instead of relying on OpenSSL since that requires to have
+                // the name of the certificates in the format "hash.0", hash being the subject hash
+                // or to have symlinks in the mentioned format to the certificates in the directory
+                std::vector<X509Wrapper> root_chain = roots.split();
+
+                for (auto& root_cert : root_chain) {
+                    trusted_parent_certificates.emplace_back(root_cert.get());
+                    trusted_wrappers.emplace_back(std::move(root_cert)); // Keep wrappers alive
+                }
+            } else {
+                X509CertificateBundle roots(root_store, EncodingFormat::PEM);
+                std::vector<X509Wrapper> root_chain = roots.split();
+
+                for (auto& root_cert : root_chain) {
+                    trusted_parent_certificates.emplace_back(root_cert.get());
+                    trusted_wrappers.emplace_back(std::move(root_cert));
+                }
+            }
         }
 
-        return validated;
+        if (trusted_parent_certificates.empty()) {
+            return CertificateValidationResult::IssuerNotFound;
+        }
+
+        return CryptoSupplier::x509_verify_certificate_chain(leaf_certificate.get(), trusted_parent_certificates,
+                                                             untrusted_subcas, true, std::nullopt, std::nullopt);
+
     } catch (const CertificateLoadException& e) {
         EVLOG_warning << "Could not validate certificate chain because of invalid format";
         return CertificateValidationResult::Unknown;

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -1744,6 +1744,7 @@ CertificateValidationResult EvseSecurity::verify_certificate(const std::string& 
 CertificateValidationResult
 EvseSecurity::verify_certificate(const std::string& certificate_chain,
                                  const std::vector<LeafCertificateType>& certificate_types) {
+    std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
     return verify_certificate_internal(certificate_chain, certificate_types);
 }
 


### PR DESCRIPTION
## Describe your changes
Added new function to the API that allows to provide multiple certificate_types / trust anchors when a certificate is verified.

This is particularly useful for verifying contract certificates for Plug&Charge, since those shall use V2G and MO root certificates as trust anchors.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

