### PR TITLE
Fix/request multi ocsp cache future valid

### DIFF
--- a/include/evse_security/certificate/x509_wrapper.hpp
+++ b/include/evse_security/certificate/x509_wrapper.hpp
@@ -110,6 +110,10 @@ public:
     /// we are not in force yet
     bool is_valid() const;
 
+    /// @brief  If the certificate will be valid in the future, that is (current date > valid_in)
+    /// and (current data > valid_to)
+    bool is_valid_in_future() const;
+
     /// @brief If the certificate has expired
     bool is_expired() const;
 

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -318,9 +318,6 @@ private:
     /// @brief Retrieves information related to leaf certificates
     GetCertificateFullInfoResult get_full_leaf_certificate_info_internal(const CertificateQueryParams& params);
 
-    OCSPRequestDataList generate_ocsp_request_data_internal(const std::set<CaCertificateType>& possible_roots,
-                                                            const std::string& leaf_chain);
-
     GetCertificateInfoResult get_ca_certificate_info_internal(CaCertificateType certificate_type);
     std::optional<fs::path> retrieve_ocsp_cache_internal(const CertificateHashData& certificate_hash_data);
 

--- a/include/evse_security/evse_security.hpp
+++ b/include/evse_security/evse_security.hpp
@@ -51,6 +51,9 @@ struct CertificateQueryParams {
     /// if true, all valid leafs will be included, sorted in order, with the newest being
     /// first. If false, only the newest one will be returned
     bool include_all_valid{false};
+    /// if true the leafs that will be valid in the future will be included, with the newest
+    /// being first
+    bool include_future_valid{false};
     /// if true, will remove all duplicates found, since we can find a leaf for example
     /// in 2 files, one in 'leaf_single' and one in 'leaf_chain'. For delete routines
     /// we need both files returned, while for queries (v2g_chain) we don't need duplicates

--- a/lib/evse_security/certificate/x509_wrapper.cpp
+++ b/lib/evse_security/certificate/x509_wrapper.cpp
@@ -115,6 +115,11 @@ bool X509Wrapper::is_valid() const {
     return (get_valid_in() <= 0) && (get_valid_to() >= 0);
 }
 
+bool X509Wrapper::is_valid_in_future() const {
+    // valid_in must be in the future, and valid_to must also be in the future
+    return (get_valid_in() > 0) && (get_valid_to() > 0);
+}
+
 bool X509Wrapper::is_expired() const {
     return (get_valid_to() < 0);
 }

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -750,6 +750,7 @@ OCSPRequestDataList EvseSecurity::get_v2g_ocsp_request_data() {
     params.include_future_valid = true;
     params.include_ocsp = false;
     params.include_root = false;
+    params.remove_duplicates = true;
 
     GetCertificateFullInfoResult result = get_full_leaf_certificate_info_internal(params);
 
@@ -2002,11 +2003,11 @@ void EvseSecurity::garbage_collect() {
                                             if (filesystem_utils::read_hash_from_file(hash_entry.path(), read_hash) &&
                                                 read_hash == ocsp_hash) {
 
-                                                auto oscp_data_path = hash_entry.path();
-                                                oscp_data_path.replace_extension(DER_EXTENSION);
+                                                auto ocsp_data_path = hash_entry.path();
+                                                ocsp_data_path.replace_extension(DER_EXTENSION);
 
                                                 invalid_certificate_files.emplace(hash_entry.path());
-                                                invalid_certificate_files.emplace(oscp_data_path);
+                                                invalid_certificate_files.emplace(ocsp_data_path);
                                             }
                                         }
                                     }

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -746,8 +746,6 @@ int EvseSecurity::get_count_of_installed_certificates(const std::vector<Certific
 OCSPRequestDataList EvseSecurity::get_v2g_ocsp_request_data() {
     std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
 
-    // TODO: we must not only use the current leaf certificate but we must get all the leafs (including future valid)
-    // and request OCSP for all
     CertificateQueryParams params;
     params.certificate_type = LeafCertificateType::V2G;
     params.encoding = EncodingFormat::PEM;

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -222,6 +222,11 @@ static std::set<fs::path> get_certificate_path_of_key(const fs::path& key, const
     throw NoCertificateValidException(error);
 }
 
+static OCSPRequestDataList
+generate_ocsp_request_data_internal(const std::map<CaCertificateType, fs::path>& ca_bundle_path_map,
+                                    const std::set<CaCertificateType>& possible_roots,
+                                    const std::vector<X509Wrapper>& leaf_chain);
+
 std::mutex EvseSecurity::security_mutex;
 
 EvseSecurity::EvseSecurity(const FilePaths& file_paths, const std::optional<std::string>& private_key_password,
@@ -772,14 +777,28 @@ OCSPRequestDataList EvseSecurity::get_v2g_ocsp_request_data() {
             EVLOG_error << "Could not load v2g ocsp cache leaf chain!";
         }
 
-        if (!chain.empty()) {
-            OCSPRequestDataList ocsp_request = generate_ocsp_request_data_internal({CaCertificateType::V2G}, chain);
+        std::vector<X509Wrapper> leaf_chain{};
 
-            // Append all retrieved data
-            full_oscp_list.ocsp_request_data_list.insert(
-                full_oscp_list.ocsp_request_data_list.end(),
-                std::make_move_iterator(ocsp_request.ocsp_request_data_list.begin()),
-                std::make_move_iterator(ocsp_request.ocsp_request_data_list.end()));
+        if (!chain.empty()) {
+            leaf_chain = std::move(X509CertificateBundle(chain, EncodingFormat::PEM).split());
+        }
+
+        if (!leaf_chain.empty()) {
+            OCSPRequestDataList partial_ocsp_request =
+                generate_ocsp_request_data_internal(this->ca_bundle_path_map, {CaCertificateType::V2G}, leaf_chain);
+
+            for (OCSPRequestData& ocsp_data : partial_ocsp_request.ocsp_request_data_list) {
+                // Add the ones that we don't already contain
+                bool not_contained =
+                    std::find_if(full_oscp_list.ocsp_request_data_list.begin(),
+                                 full_oscp_list.ocsp_request_data_list.end(), [&ocsp_data](auto& existing) {
+                                     return (ocsp_data.certificate_hash_data == existing.certificate_hash_data);
+                                 }) == full_oscp_list.ocsp_request_data_list.end();
+
+                if (not_contained) {
+                    full_oscp_list.ocsp_request_data_list.emplace_back(std::move(ocsp_data));
+                }
+            }
         }
     }
 
@@ -789,25 +808,32 @@ OCSPRequestDataList EvseSecurity::get_v2g_ocsp_request_data() {
 OCSPRequestDataList EvseSecurity::get_mo_ocsp_request_data(const std::string& certificate_chain) {
     std::lock_guard<std::mutex> guard(EvseSecurity::security_mutex);
 
-    // Test for both MO and V2G roots
-    return generate_ocsp_request_data_internal({CaCertificateType::V2G, CaCertificateType::MO}, certificate_chain);
+    try {
+        std::vector<X509Wrapper> leaf_chain = X509CertificateBundle(certificate_chain, EncodingFormat::PEM).split();
+
+        // Test for both MO and V2G roots
+        return generate_ocsp_request_data_internal(this->ca_bundle_path_map,
+                                                   {CaCertificateType::V2G, CaCertificateType::MO}, leaf_chain);
+    } catch (const CertificateLoadException& e) {
+        EVLOG_error << "Could not load mo ocsp cache leaf chain!";
+    }
+
+    return {};
 }
 
-OCSPRequestDataList EvseSecurity::generate_ocsp_request_data_internal(const std::set<CaCertificateType>& possible_roots,
-                                                                      const std::string& leaf_chain) {
+static OCSPRequestDataList
+generate_ocsp_request_data_internal(const std::map<CaCertificateType, fs::path>& ca_bundle_path_map,
+                                    const std::set<CaCertificateType>& possible_roots,
+                                    const std::vector<X509Wrapper>& leaf_chain) {
     OCSPRequestDataList response;
 
-    std::vector<X509Wrapper> chain;
-    try {
-        chain = std::move(X509CertificateBundle(leaf_chain, EncodingFormat::PEM).split());
-    } catch (const CertificateLoadException& e) {
-        EVLOG_error << "Could not generate ocsp request, leaf certificate load failure: " << e.what();
+    if (leaf_chain.empty()) {
         return response;
     }
 
     std::vector<X509Wrapper> full_root_hierarchy;
     for (const CaCertificateType& root_type : possible_roots) {
-        const fs::path& root_path = this->ca_bundle_path_map.at(root_type);
+        const fs::path& root_path = ca_bundle_path_map.at(root_type);
         std::vector<X509Wrapper> root_hierarchy = X509CertificateBundle(root_path, EncodingFormat::PEM).split();
 
         full_root_hierarchy.insert(full_root_hierarchy.end(), std::make_move_iterator(root_hierarchy.begin()),
@@ -817,7 +843,7 @@ OCSPRequestDataList EvseSecurity::generate_ocsp_request_data_internal(const std:
     std::vector<OCSPRequestData> ocsp_request_data_list;
     try {
         // Build the full hierarchy
-        auto hierarchy = std::move(X509CertificateHierarchy::build_hierarchy(full_root_hierarchy, chain));
+        auto hierarchy = std::move(X509CertificateHierarchy::build_hierarchy(full_root_hierarchy, leaf_chain));
 
         // Search for the first valid root, and collect all the chain
         for (auto& root : hierarchy.get_hierarchy()) {
@@ -833,7 +859,7 @@ OCSPRequestDataList EvseSecurity::generate_ocsp_request_data_internal(const std:
                 // We must make sure that the full received 'leaf_chain' is present in the descendants
                 bool missing_link = false;
 
-                for (const X509Wrapper& received_chain_link : chain) {
+                for (const X509Wrapper& received_chain_link : leaf_chain) {
                     bool descendants_contain =
                         std::find(descendants.begin(), descendants.end(), received_chain_link) != descendants.end();
 
@@ -916,36 +942,43 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
 
             for (auto& cert : certs) {
                 EVLOG_debug << "Writing OCSP Response to filesystem";
-                if (cert.get_file().has_value()) {
-                    const auto ocsp_path = cert.get_file().value().parent_path() / "ocsp";
 
-                    if (false == fs::exists(ocsp_path)) {
-                        filesystem_utils::create_file_or_dir_if_nonexistent(ocsp_path);
-                    } else {
-                        // Iterate existing hashes
-                        for (const auto& hash_entry : fs::directory_iterator(ocsp_path)) {
-                            if (hash_entry.is_regular_file()) {
-                                CertificateHashData read_hash;
+                if (!cert.get_file().has_value()) {
+                    EVLOG_error << "Could not find OCSP cache path directory!";
+                    continue;
+                }
 
-                                if (filesystem_utils::read_hash_from_file(hash_entry.path(), read_hash) &&
-                                    read_hash == certificate_hash_data) {
-                                    EVLOG_debug << "OCSP certificate hash already found, over-writing!";
+                const auto ocsp_path = cert.get_file().value().parent_path() / "ocsp";
+                bool updated_hash = false;
 
-                                    // Over-write the data file and return
-                                    fs::path ocsp_path = hash_entry.path();
-                                    ocsp_path.replace_extension(DER_EXTENSION);
+                if (false == fs::exists(ocsp_path)) {
+                    filesystem_utils::create_file_or_dir_if_nonexistent(ocsp_path);
+                } else {
+                    // Iterate existing hashes
+                    for (const auto& hash_entry : fs::directory_iterator(ocsp_path)) {
+                        if (hash_entry.is_regular_file()) {
+                            CertificateHashData read_hash;
 
-                                    // Discard previous content
-                                    std::ofstream fs(ocsp_path.c_str(), std::ios::trunc);
-                                    fs << ocsp_response;
-                                    fs.close();
+                            if (filesystem_utils::read_hash_from_file(hash_entry.path(), read_hash) &&
+                                read_hash == certificate_hash_data) {
+                                EVLOG_debug << "OCSP certificate hash already found, over-writing!";
 
-                                    return;
-                                }
+                                // Over-write the data file and return
+                                fs::path ocsp_path = hash_entry.path();
+                                ocsp_path.replace_extension(DER_EXTENSION);
+
+                                // Discard previous content
+                                std::ofstream fs(ocsp_path.c_str(), std::ios::trunc);
+                                fs << ocsp_response;
+                                fs.close();
+
+                                updated_hash = true;
                             }
                         }
                     }
+                }
 
+                if (!updated_hash) {
                     // Randomize filename, since multiple certificates can be stored in same bundle
                     const auto name = filesystem_utils::get_random_file_name("_ocsp");
 
@@ -966,8 +999,6 @@ void EvseSecurity::update_ocsp_cache(const CertificateHashData& certificate_hash
                     }
 
                     EVLOG_debug << "OCSP certificate hash not found, written at path: " << ocsp_file_path;
-                } else {
-                    EVLOG_error << "Could not find OCSP cache patch directory!";
                 }
             }
         } catch (const NoCertificateFound& e) {
@@ -1274,16 +1305,17 @@ EvseSecurity::get_full_leaf_certificate_info_internal(const CertificateQueryPara
         // Iterate all certificates from newest to the oldest
         leaf_certificates.for_each_chain_ordered(
             [&](const fs::path& file, const std::vector<X509Wrapper>& chain) {
-                // Search for the first valid where we can find a key
-                bool is_valid;
+                bool is_valid = false;
 
-                if (params.include_future_valid) {
-                    is_valid = chain.at(0).is_valid_in_future();
-                } else {
-                    is_valid = chain.at(0).is_valid();
+                if (not chain.empty()) {
+                    is_valid |= chain.at(0).is_valid();
+
+                    if (params.include_future_valid) {
+                        is_valid |= chain.at(0).is_valid_in_future();
+                    }
                 }
 
-                if (not chain.empty() && chain.at(0).is_valid()) {
+                if (is_valid) {
                     any_valid_certificate = true;
 
                     try {

--- a/tests/configs/seccLeafCert.cnf
+++ b/tests/configs/seccLeafCert.cnf
@@ -12,4 +12,4 @@ domainComponent			= CPO
 basicConstraints		= critical,CA:false
 keyUsage				= critical,digitalSignature,keyAgreement
 subjectKeyIdentifier	= hash
-
+authorityInfoAccess = OCSP;URI:https://www.example.com/, caIssuers;URI:https://www.example.com/Leaf-CA.cer

--- a/tests/configs/seccLeafCert_Alternate.cnf
+++ b/tests/configs/seccLeafCert_Alternate.cnf
@@ -12,4 +12,4 @@ domainComponent			= CPO
 basicConstraints		= critical,CA:false
 keyUsage				= critical,digitalSignature,keyAgreement
 subjectKeyIdentifier	= hash
-
+authorityInfoAccess = OCSP;URI:https://www.example.com/, caIssuers;URI:https://www.example.com/Leaf-CA.cer

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -835,7 +835,7 @@ TEST_F(EvseSecurityTests, verify_full_filesystem_install_reject) {
     ASSERT_TRUE(result == InstallCertificateResult::CertificateStoreMaxLengthExceeded);
 }
 
-TEST_F(EvseSecurityTests, verify_oscp_request_mo_generate) {
+TEST_F(EvseSecurityTests, verify_ocsp_request_mo_generate) {
     // Read a leaf, should work since this SECC will be tested against both MO and V2G
     const auto secc_leaf = read_file_to_string("certs/client/cso/SECC_LEAF.pem");
     OCSPRequestDataList data = this->evse_security->get_mo_ocsp_request_data(secc_leaf);
@@ -871,7 +871,7 @@ TEST_F(EvseSecurityTests, verify_oscp_request_mo_generate) {
     ASSERT_EQ(data.ocsp_request_data_list[1].certificate_hash_data.value().debug_common_name, std::string("CPOSubCA1"));
 }
 
-TEST_F(EvseSecurityTests, verify_oscp_cache) {
+TEST_F(EvseSecurityTests, verify_ocsp_cache) {
     std::string ocsp_mock_response_data = "OCSP_MOCK_RESPONSE_DATA";
     std::string ocsp_mock_response_data_v2 = "OCSP_MOCK_RESPONSE_DATA_V2";
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -835,19 +835,67 @@ TEST_F(EvseSecurityTests, verify_full_filesystem_install_reject) {
     ASSERT_TRUE(result == InstallCertificateResult::CertificateStoreMaxLengthExceeded);
 }
 
+TEST_F(EvseSecurityTestsMultiLeaf, verify_ocsp_request_multi_valid) {
+    // Verify the OCSP request when we have multiple possible valid certificates
+    OCSPRequestDataList data = this->evse_security->get_v2g_ocsp_request_data();
+    ASSERT_EQ(data.ocsp_request_data_list.size(), 4);
+
+    ASSERT_TRUE(data.ocsp_request_data_list[0].certificate_hash_data.has_value());
+    ASSERT_TRUE(data.ocsp_request_data_list[1].certificate_hash_data.has_value());
+    ASSERT_TRUE(data.ocsp_request_data_list[2].certificate_hash_data.has_value());
+    ASSERT_TRUE(data.ocsp_request_data_list[3].certificate_hash_data.has_value());
+
+    ASSERT_TRUE(
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("CPOSubCA2");
+        }) != data.ocsp_request_data_list.end());
+
+    ASSERT_TRUE(
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("CPOSubCA1");
+        }) != data.ocsp_request_data_list.end());
+
+    ASSERT_TRUE(
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("SECCCert");
+        }) != data.ocsp_request_data_list.end());
+
+    ASSERT_TRUE(
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("SECCGridSyncCert");
+        }) != data.ocsp_request_data_list.end());
+}
+
 TEST_F(EvseSecurityTests, verify_ocsp_request_mo_generate) {
     // Read a leaf, should work since this SECC will be tested against both MO and V2G
     const auto secc_leaf = read_file_to_string("certs/client/cso/SECC_LEAF.pem");
     OCSPRequestDataList data = this->evse_security->get_mo_ocsp_request_data(secc_leaf);
 
-    // Expect 2 chain certifs, since SECC_LEAF does not have an responder URL
-    ASSERT_EQ(data.ocsp_request_data_list.size(), 2);
+    // Expect 3 chain certifs, since SECC_LEAF has an responder URL
+    ASSERT_EQ(data.ocsp_request_data_list.size(), 3);
 
     // Assert a leaf->sub2->sub1 order
     ASSERT_TRUE(data.ocsp_request_data_list[0].certificate_hash_data.has_value());
     ASSERT_TRUE(data.ocsp_request_data_list[1].certificate_hash_data.has_value());
-    ASSERT_EQ(data.ocsp_request_data_list[0].certificate_hash_data.value().debug_common_name, std::string("CPOSubCA2"));
-    ASSERT_EQ(data.ocsp_request_data_list[1].certificate_hash_data.value().debug_common_name, std::string("CPOSubCA1"));
+    ASSERT_TRUE(data.ocsp_request_data_list[2].certificate_hash_data.has_value());
+
+    bool has_intermediate_1 =
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("CPOSubCA1");
+        }) != data.ocsp_request_data_list.end();
+    ASSERT_TRUE(has_intermediate_1);
+
+    bool has_intermediate_2 =
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("CPOSubCA2");
+        }) != data.ocsp_request_data_list.end();
+    ASSERT_TRUE(has_intermediate_2);
+
+    bool has_leaf =
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("SECCCert");
+        }) != data.ocsp_request_data_list.end();
+    ASSERT_TRUE(has_leaf);
 
     // Read the MO leaf
     const auto mo_leaf = read_file_to_string("certs/client/mo/MO_LEAF.pem");
@@ -857,18 +905,39 @@ TEST_F(EvseSecurityTests, verify_ocsp_request_mo_generate) {
     ASSERT_EQ(data.ocsp_request_data_list.size(), 2);
     ASSERT_TRUE(data.ocsp_request_data_list[0].certificate_hash_data.has_value());
     ASSERT_TRUE(data.ocsp_request_data_list[1].certificate_hash_data.has_value());
-    ASSERT_EQ(data.ocsp_request_data_list[0].certificate_hash_data.value().debug_common_name, std::string("MOSubCA2"));
-    ASSERT_EQ(data.ocsp_request_data_list[1].certificate_hash_data.value().debug_common_name, std::string("MOSubCA1"));
+
+    has_intermediate_1 =
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("MOSubCA2");
+        }) != data.ocsp_request_data_list.end();
+    ASSERT_TRUE(has_intermediate_1);
+
+    has_intermediate_2 =
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("MOSubCA1");
+        }) != data.ocsp_request_data_list.end();
+    ASSERT_TRUE(has_intermediate_2);
 
     // Read the MO signed by V2G leaf
     const auto mo_v2g_leaf = read_file_to_string("certs/client/mo/MO_LEAF_V2G.pem");
     data = this->evse_security->get_mo_ocsp_request_data(mo_v2g_leaf);
 
+    // Again expect 2 since the mo leaf does not have a responder URL
     ASSERT_EQ(data.ocsp_request_data_list.size(), 2);
     ASSERT_TRUE(data.ocsp_request_data_list[0].certificate_hash_data.has_value());
     ASSERT_TRUE(data.ocsp_request_data_list[1].certificate_hash_data.has_value());
-    ASSERT_EQ(data.ocsp_request_data_list[0].certificate_hash_data.value().debug_common_name, std::string("CPOSubCA2"));
-    ASSERT_EQ(data.ocsp_request_data_list[1].certificate_hash_data.value().debug_common_name, std::string("CPOSubCA1"));
+
+    has_intermediate_1 =
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("CPOSubCA1");
+        }) != data.ocsp_request_data_list.end();
+    ASSERT_TRUE(has_intermediate_1);
+
+    has_intermediate_2 =
+        std::find_if(data.ocsp_request_data_list.begin(), data.ocsp_request_data_list.end(), [](const auto& ocsp_data) {
+            return ocsp_data.certificate_hash_data.value().debug_common_name == std::string("CPOSubCA2");
+        }) != data.ocsp_request_data_list.end();
+    ASSERT_TRUE(has_intermediate_2);
 }
 
 TEST_F(EvseSecurityTests, verify_ocsp_cache) {
@@ -877,7 +946,7 @@ TEST_F(EvseSecurityTests, verify_ocsp_cache) {
 
     OCSPRequestDataList data = this->evse_security->get_v2g_ocsp_request_data();
 
-    ASSERT_EQ(data.ocsp_request_data_list.size(), 2);
+    ASSERT_EQ(data.ocsp_request_data_list.size(), 3);
 
     // Mock a response
     for (auto& ocsp : data.ocsp_request_data_list) {
@@ -885,7 +954,7 @@ TEST_F(EvseSecurityTests, verify_ocsp_cache) {
     }
 
     // Make sure all info was written and that it is correct
-    fs::path ocsp_path = "certs/ca/v2g/ocsp";
+    fs::path ocsp_path = "certs/client/cso/ocsp";
 
     ASSERT_TRUE(fs::exists(ocsp_path));
 
@@ -921,7 +990,7 @@ TEST_F(EvseSecurityTests, verify_ocsp_cache) {
         entries++;
     }
 
-    ASSERT_EQ(entries, 4); // 2 for hash, 2 for data
+    ASSERT_EQ(entries, 6); // 3 for hash, 3 for data
 
     // Write data again to test over-writing
     for (auto& ocsp : data.ocsp_request_data_list) {
@@ -961,7 +1030,7 @@ TEST_F(EvseSecurityTests, verify_ocsp_cache) {
         entries++;
     }
 
-    ASSERT_EQ(entries, 4); // 4 still, since we have to over-write
+    ASSERT_EQ(entries, 6); // 6 still, since we have to over-write
 
     // Retrieve OCSP data along with certificates
     GetCertificateInfoResult response =
@@ -988,7 +1057,7 @@ TEST_F(EvseSecurityTests, verify_ocsp_garbage_collect) {
     std::string ocsp_mock_response_data = "OCSP_MOCK_RESPONSE_DATA";
 
     OCSPRequestDataList data = this->evse_security->get_v2g_ocsp_request_data();
-    ASSERT_EQ(data.ocsp_request_data_list.size(), 2);
+    ASSERT_EQ(data.ocsp_request_data_list.size(), 3);
 
     // Mock a response
     for (auto& ocsp : data.ocsp_request_data_list) {
@@ -1027,7 +1096,7 @@ TEST_F(EvseSecurityTests, verify_ocsp_garbage_collect) {
         }
     }
 
-    ASSERT_EQ(existing, 8);
+    ASSERT_EQ(existing, 10);
 
     // Delete the certificates that had their OCSP data appended
     fs::remove("certs/ca/v2g/V2G_CA_BUNDLE.pem");


### PR DESCRIPTION
## Describe your changes

Now the lib will generate multiple OCSP requests for certificates that are not yet valid, but will become so in the future.

A test case for checking multi-ocsp generation has been added, and existing tests have been modified to accommodate the new feature.

## Issue ticket number and link

Closes: https://github.com/EVerest/libevse-security/issues/108

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

