### PR TITLE
OpenSSL TMP2 configuration improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,18 +27,18 @@ if(USING_TPM2 AND USING_CUSTOM_PROVIDER)
 endif()
 
 if(USING_TPM2)
-    set(CUSTOM_PROVIDER_NAME "tpm2")    
+    set(CUSTOM_PROVIDER_NAME "tpm2")
 endif()
 
 if(USING_CUSTOM_PROVIDER)
-    set(CUSTOM_PROVIDER_NAME "custom_provider")    
+    set(CUSTOM_PROVIDER_NAME "custom_provider")
 endif()
 
 if(USING_TPM2 OR USING_CUSTOM_PROVIDER)
 # OpenSSL property string when using the default provider
-    set(PROPQUERY_PROVIDER_DEFAULT "provider!=${CUSTOM_PROVIDER_NAME}")
+    set(PROPQUERY_PROVIDER_DEFAULT "?provider=default")
     # OpenSSL property string when using the tpm2/custom provider
-    set(PROPQUERY_PROVIDER_CUSTOM "?provider=${CUSTOM_PROVIDER_NAME},${CUSTOM_PROVIDER_NAME}.digest!=yes,${CUSTOM_PROVIDER_NAME}.cipher!=yes")
+    set(PROPQUERY_PROVIDER_CUSTOM "?provider=${CUSTOM_PROVIDER_NAME}")
 endif()
 
 # dependencies
@@ -96,4 +96,3 @@ if(LIBEVSE_SECURITY_BUILD_TESTING)
     add_subdirectory(tests)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
-

--- a/include/evse_security/crypto/openssl/openssl_provider.hpp
+++ b/include/evse_security/crypto/openssl/openssl_provider.hpp
@@ -148,6 +148,12 @@ public:
     inline const char* propquery_tls_str() const {
         return propquery(propquery_tls());
     }
+    inline const char* propquery_default() const {
+        return propquery(mode_t::default_provider);
+    }
+    inline const char* propquery_custom() const {
+        return propquery(mode_t::custom_provider);
+    }
 
     /// @brief return the TLS OSSL library context
     inline operator struct ossl_lib_ctx_st *() {

--- a/lib/evse_security/CMakeLists.txt
+++ b/lib/evse_security/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(evse_security
 
 if (LIBEVSE_CRYPTO_SUPPLIER_OPENSSL)
     target_sources(evse_security
-        PRIVATE                 
+        PRIVATE
             crypto/openssl/openssl_crypto_supplier.cpp
             crypto/openssl/openssl_provider.cpp
     )
@@ -80,7 +80,7 @@ target_link_libraries(evse_security
 
 if(LIBEVSE_SECURITY_BUILD_TESTING)
     target_compile_definitions(evse_security PRIVATE
-        DEBUG_MODE_EVSE_SECURITY       
+        DEBUG_MODE_EVSE_SECURITY
     )
 endif()
 

--- a/lib/evse_security/crypto/openssl/openssl_provider.cpp
+++ b/lib/evse_security/crypto/openssl/openssl_provider.cpp
@@ -141,6 +141,7 @@ OpenSSLProvider::OpenSSLProvider() {
 }
 
 OpenSSLProvider::~OpenSSLProvider() {
+    set_global_mode(OpenSSLProvider::mode_t::default_provider);
     s_mux.unlock();
 }
 


### PR DESCRIPTION
## Describe your changes
The general approach is to load the default and TPM2 providers into OpenSSL and use property query strings to control when the TPM is used. There is a mutex to ensure that multi-threaded code doesn't attempt to change the settings until the required operation is complete.

Testing of the approach has identified weaknesses where the TPM is used for operations that can be performed by the default provider. e.g. generating random numbers and verifying digital signatures (only the public key is required)

The new approach is to set a preferred provider and the OpenSSLProvider object always resets the global property query string to prefer the default provider in the destructor.
 
As a result the only time a OpenSSLProvider change is needed is when creating a new key.
Using the key later OpenSSL will prefer the default provider but will use the tpm2 provider if the key requires it.

This also reduces the number of OpenSSLProvider uses since resetting back to default is no longer required.

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

