### PR TITLE
Fix a too early return in add_certificate_unique()

### DIFF
--- a/lib/evse_security/certificate/x509_bundle.cpp
+++ b/lib/evse_security/certificate/x509_bundle.cpp
@@ -254,7 +254,7 @@ void X509CertificateBundle::add_certificate(X509Wrapper&& certificate) {
 
 void X509CertificateBundle::add_certificate_unique(X509Wrapper&& certificate) {
     if (!contains_certificate(certificate)) {
-        return add_certificate(std::move(certificate));
+        add_certificate(std::move(certificate));
         invalidate_hierarchy();
     }
 }


### PR DESCRIPTION
This returned too early (and potentially with a value in a void function) never calling invalidate_hierarchy()

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

