### PR TITLE
Fix compilation errors for older versions of GCC using Boost filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(everest-evse_security VERSION 0.10.0
+project(everest-evse_security VERSION 0.10.1
         DESCRIPTION "Implementation of EVSE related security operations"
 		LANGUAGES CXX C
 )

--- a/include/evse_security/certificate/x509_bundle.hpp
+++ b/include/evse_security/certificate/x509_bundle.hpp
@@ -158,7 +158,7 @@ public:
     std::string to_export_string() const;
 
     /// @brief Returns a full exportable representation of a certificate sub-chain, if found
-    std::string to_export_string(const std::filesystem::path& chain) const;
+    std::string to_export_string(const fs::path& chain) const;
 
     /// @brief Exports the full certificate chain either as individual files if it is using a directory
     /// or as a bundle if it uses a bundle file, at the initially provided path. Also deletes/adds the updated

--- a/include/evse_security/certificate/x509_hierarchy.hpp
+++ b/include/evse_security/certificate/x509_hierarchy.hpp
@@ -135,7 +135,11 @@ public:
         X509CertificateHierarchy ordered;
 
         (std::for_each(certificates.begin(), certificates.end(),
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 9)
+                       [ordered_ptr = &ordered](X509Wrapper& cert) { ordered_ptr->insert(std::move(cert)); }),
+#else
                        [&ordered](X509Wrapper& cert) { ordered.insert(std::move(cert)); }),
+#endif
          ...); // Fold expr
 
         // Prune the tree

--- a/include/evse_security/crypto/interface/crypto_types.hpp
+++ b/include/evse_security/crypto/interface/crypto_types.hpp
@@ -2,6 +2,8 @@
 // Copyright Pionix GmbH and Contributors to EVerest
 #pragma once
 
+#include <evse_security/utils/evse_filesystem_types.hpp>
+
 #include <chrono>
 #include <memory>
 #include <optional>
@@ -46,10 +48,10 @@ struct KeyGenerationInfo {
     bool generate_on_custom;
 
     /// @brief If we should export the public key to a file
-    std::optional<std::string> public_key_file;
+    std::optional<fs::path> public_key_file;
 
     /// @brief If we should export the private key to a file
-    std::optional<std::string> private_key_file;
+    std::optional<fs::path> private_key_file;
     /// @brief If we should have a pass for the private key file
     std::optional<std::string> private_key_pass;
 };

--- a/include/evse_security/utils/evse_filesystem_types.hpp
+++ b/include/evse_security/utils/evse_filesystem_types.hpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #else
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 #endif
 
 #ifndef LIBEVSE_SECURITY_USE_BOOST_FILESYSTEM

--- a/lib/evse_security/CMakeLists.txt
+++ b/lib/evse_security/CMakeLists.txt
@@ -90,6 +90,10 @@ if(LIBEVSE_SECURITY_USE_BOOST_FILESYSTEM)
         PRIVATE
             Boost::filesystem
     )
+    target_compile_definitions(evse_security
+        PRIVATE
+            LIBEVSE_SECURITY_USE_BOOST_FILESYSTEM
+    )
 endif()
 
 if(LIBEVSE_CRYPTO_SUPPLIER_OPENSSL)

--- a/lib/evse_security/certificate/x509_bundle.cpp
+++ b/lib/evse_security/certificate/x509_bundle.cpp
@@ -101,7 +101,7 @@ int X509CertificateBundle::get_certificate_chains_count() const {
 void X509CertificateBundle::add_certificates(const std::string& data, const EncodingFormat encoding,
                                              const std::optional<fs::path>& path) {
     auto loaded = CryptoSupplier::load_certificates(data, encoding);
-    auto& list = certificates[path.value_or(std::filesystem::path())];
+    auto& list = certificates[path.value_or(fs::path())];
 
     for (auto& x509 : loaded) {
         if (path.has_value()) {
@@ -239,7 +239,7 @@ void X509CertificateBundle::delete_all_certificates() {
 void X509CertificateBundle::add_certificate(X509Wrapper&& certificate) {
     if (source == X509CertificateSource::DIRECTORY) {
         // If it is in directory mode only allow sub-directories of that directory
-        const std::filesystem::path certif_path = certificate.get_file().value_or(std::filesystem::path());
+        const fs::path certif_path = certificate.get_file().value_or(fs::path());
 
         if (filesystem_utils::is_subdirectory(path, certif_path)) {
             certificates[certif_path].push_back(std::move(certificate));
@@ -309,7 +309,6 @@ bool X509CertificateBundle::export_certificates() {
     }
     if (source == X509CertificateSource::FILE) {
         // write to a separate file to minimise corruption and data loss; then rename
-        namespace fs = std::filesystem;
         bool result{false};
 
         try {
@@ -420,7 +419,7 @@ std::string X509CertificateBundle::to_export_string() const {
     return export_string;
 }
 
-std::string X509CertificateBundle::to_export_string(const std::filesystem::path& chain) const {
+std::string X509CertificateBundle::to_export_string(const fs::path& chain) const {
     std::string export_string;
 
     auto found = certificates.find(chain);

--- a/lib/evse_security/crypto/openssl/openssl_provider.cpp
+++ b/lib/evse_security/crypto/openssl/openssl_provider.cpp
@@ -38,7 +38,7 @@ bool is_custom_private_key_string(const std::string& private_key_pem) {
 
 bool is_custom_private_key_file(const fs::path& private_key_file_pem) {
     if (fs::is_regular_file(private_key_file_pem)) {
-        std::ifstream key_file(private_key_file_pem);
+        fsstd::ifstream key_file(private_key_file_pem);
         std::string line;
         std::getline(key_file, line);
         key_file.close();

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -220,9 +220,9 @@ std::set<fs::path> get_certificate_path_of_key(const fs::path& key, const fs::pa
     }
 
     std::string error = "Could not find certificate for given private key: ";
-    error += key;
+    error += key.string();
     error += " certificates path: ";
-    error += certificate_path_directory;
+    error += certificate_path_directory.string();
 
     throw NoCertificateValidException(error);
 }
@@ -1527,7 +1527,7 @@ EvseSecurity::get_full_leaf_certificate_info_internal(const CertificateQueryPara
             // We are searching for both the full leaf bundle, containing the leaf and the cso1/2 and the single
             // leaf without the cso1/2
             leaf_directory.for_each_chain(
-                [&](const std::filesystem::path& /*path*/, const std::vector<X509Wrapper>& chain) {
+                [&](const fs::path& /*path*/, const std::vector<X509Wrapper>& chain) {
                     // If we contain the latest valid, we found our generated bundle
                     const bool leaf_found = (std::find(chain.begin(), chain.end(), certificate) != chain.end());
 
@@ -1831,7 +1831,7 @@ std::string EvseSecurity::get_verify_location(CaCertificateType certificate_type
 
         if (!verify_location.empty() &&
             (!verify_location.is_using_directory() || hash_dir(location_path.c_str()) == 0)) {
-            return location_path;
+            return location_path.string();
         }
 
     } catch (const CertificateLoadException& e) {

--- a/lib/evse_security/evse_security.cpp
+++ b/lib/evse_security/evse_security.cpp
@@ -1526,27 +1526,26 @@ EvseSecurity::get_full_leaf_certificate_info_internal(const CertificateQueryPara
 
             // We are searching for both the full leaf bundle, containing the leaf and the cso1/2 and the single
             // leaf without the cso1/2
-            leaf_directory.for_each_chain(
-                [&](const fs::path& /*path*/, const std::vector<X509Wrapper>& chain) {
-                    // If we contain the latest valid, we found our generated bundle
-                    const bool leaf_found = (std::find(chain.begin(), chain.end(), certificate) != chain.end());
+            leaf_directory.for_each_chain([&](const fs::path& /*path*/, const std::vector<X509Wrapper>& chain) {
+                // If we contain the latest valid, we found our generated bundle
+                const bool leaf_found = (std::find(chain.begin(), chain.end(), certificate) != chain.end());
 
-                    if (leaf_found) {
-                        if (chain.size() > 1) {
-                            leaf_fullchain = &chain;
-                            chain_len = chain.size();
-                        } else if (chain.size() == 1) {
-                            leaf_single = &chain;
-                        }
+                if (leaf_found) {
+                    if (chain.size() > 1) {
+                        leaf_fullchain = &chain;
+                        chain_len = chain.size();
+                    } else if (chain.size() == 1) {
+                        leaf_single = &chain;
                     }
+                }
 
-                    // Found both, break
-                    if (leaf_fullchain != nullptr && leaf_single != nullptr) {
-                        return false;
-                    }
+                // Found both, break
+                if (leaf_fullchain != nullptr && leaf_single != nullptr) {
+                    return false;
+                }
 
-                    return true;
-                });
+                return true;
+            });
 
             std::vector<CertificateOCSP> certificate_ocsp{};
             std::optional<std::string> leafs_root = std::nullopt;

--- a/lib/evse_security/utils/evse_filesystem.cpp
+++ b/lib/evse_security/utils/evse_filesystem.cpp
@@ -56,7 +56,7 @@ bool create_file_if_nonexistent(const fs::path& file_path) {
 
     try {
         if (!fs::exists(file_path)) {
-            const std::ofstream file(file_path);
+            const fsstd::ofstream file(file_path);
             return true;
         }
         if (fs::is_directory(file_path)) {
@@ -118,7 +118,7 @@ bool write_to_file(const fs::path& file_path, const std::string& data, std::ios:
 
 bool process_file(const fs::path& file_path, size_t buffer_size,
                   std::function<bool(const std::uint8_t*, std::size_t, bool last_chunk)>&& func) {
-    std::ifstream file(file_path, std::ios::binary);
+    fsstd::ifstream file(file_path, std::ios::binary);
 
     if (!file) {
         EVLOG_error << "Error opening file: " << file_path;
@@ -166,7 +166,7 @@ std::string get_random_file_name(const std::string& extension) {
 bool read_hash_from_file(const fs::path& file_path, CertificateHashData& out_hash) {
     if (file_path.extension() == CERT_HASH_EXTENSION) {
         try {
-            std::ifstream hs(file_path);
+            fsstd::ifstream hs(file_path);
             std::string algo;
 
             hs >> algo;


### PR DESCRIPTION
## Describe your changes

Fix compilation error in older C++ compilers with missing std::filesystem implementation by ensuring that all usages of `std::filesystem` are replaced with the alias `fs`, and all usages of fstreams with `boost::filesystem`.

## Issue ticket number and link

Issue #128
Link: https://github.com/EVerest/libevse-security/issues/128

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [N/A] I have made corresponding changes to the documentation
  - I don't think any documentation changes are needed for this, please correct me if I'm wrong.
- [X] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

